### PR TITLE
feat: allow per-push config for GCM

### DIFF
--- a/test/gcm_test.exs
+++ b/test/gcm_test.exs
@@ -14,6 +14,16 @@ defmodule Pigeon.GCMTest do
     assert result == :ok
   end
 
+  test "successfully sends a valid push with an explicit config" do
+    reg_id = Application.get_env(:pigeon, :valid_gcm_reg_id)
+    result =
+      reg_id
+      |> Pigeon.GCM.Notification.new(%{}, @data)
+      |> Pigeon.GCM.push(%{gcm_key: System.get_env("GCM_KEY")})
+
+    assert result == :ok
+  end
+
   test "successfully sends a valid push with callback" do
     reg_id = Application.get_env(:pigeon, :valid_gcm_reg_id)
     n = Pigeon.GCM.Notification.new(reg_id, %{}, @data)


### PR DESCRIPTION
The GCM notifications can now be configured on an ad-hoc basis by
passing a map as the second argument. If the second argument is not
specified then the value from the config will be used.

This allows multiple tokens to be used. For example you support multiple Android apps from the same server. Or if you are using a separate GCM token for Android and Web. 