### PR TITLE
feat: make apn topic optional

### DIFF
--- a/lib/pigeon/apns_worker.ex
+++ b/lib/pigeon/apns_worker.ex
@@ -95,9 +95,9 @@ defmodule Pigeon.APNSWorker do
     req_headers = [
       {":method", "POST"},
       {":path", "/3/device/#{notification.device_token}"},
-      {"apns-topic", notification.topic},
       {"content-length", "#{byte_size(json)}"}]
       |> put_apns_id(notification)
+      |> put_apns_topic(notification)
 
     :h2_client.send_request(socket, req_headers, json)
     new_q = Map.put(queue, "#{stream_id}", {notification, on_response})
@@ -109,6 +109,13 @@ defmodule Pigeon.APNSWorker do
     case notification.id do
       nil -> headers
       id -> headers ++ [{"apns-id", id}]
+    end
+  end
+
+  defp put_apns_topic(headers, notification) do
+    case notification.topic do
+      nil   -> headers
+      topic -> headers ++ [{"apns-topic", topic}]
     end
   end
 

--- a/lib/pigeon/notification.ex
+++ b/lib/pigeon/notification.ex
@@ -21,7 +21,7 @@ defmodule Pigeon.APNS.Notification do
   """
   defstruct device_token: nil, payload: %{"aps" => %{}}, expiration: nil, topic: nil, id: nil
 
-  def new(msg, token, topic) do
+  def new(msg, token, topic \\ nil) do
     %Pigeon.APNS.Notification{
       device_token: token,
       topic: topic,


### PR DESCRIPTION
From the developer docs[1]:

 > If you omit this header and your APNs certificate does not specify
 > multiple topics, the APNs server uses the certificate’s Subject as
 > the default topic.

[1] https://goo.gl/v3nJZm