### PR TITLE
Adds a function to add the mutable-content flag to APNs, for notification content preview on iOS 10

### DIFF
--- a/lib/pigeon/notification.ex
+++ b/lib/pigeon/notification.ex
@@ -48,6 +48,8 @@ defmodule Pigeon.APNS.Notification do
 
   def put_category(notification, category), do: update_payload(notification, "category", category)
 
+  def put_mutable_content(notification), do: update_payload(notification, "mutable-content", 1)
+
   defp update_payload(notification, key, value) do
     new_aps =
       notification.payload

--- a/test/apns_notification_test.exs
+++ b/test/apns_notification_test.exs
@@ -67,6 +67,15 @@ defmodule Pigeon.APNSNotificationTest do
     assert n.payload == %{"aps" => %{"alert" => test_msg, "category" => category}}
   end
 
+  test "put_mutable_content" do
+    n =
+      test_msg
+      |> Pigeon.APNS.Notification.new(test_device_token, test_topic)
+      |> Pigeon.APNS.Notification.put_mutable_content
+
+    assert n.payload == %{"aps" => %{"alert" => test_msg, "mutable-content" => 1}}
+  end
+
   test "put_custom" do
     custom = %{"custom-key" => %{"custom-value" => 500}}
     n =


### PR DESCRIPTION
This PR adds a function so that the user can add a `mutable-content` flag to the `aps` dictionary, which indicates iOS 10 that there's content to be fetched to show within the notification using Service Extension.