### PR TITLE
travis: run tests on Erlang 18.3 and Erlang 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: elixir
-elixir:
-- 1.3.2
+matrix:
+  include:
+    - otp_release: 18.3
+      elixir: 1.3.2
+    - otp_release: 19.0
+      elixir: 1.3.2
 before_install:
 - openssl aes-256-cbc -K $encrypted_944d6c2c1357_key -iv $encrypted_944d6c2c1357_iv
   -in cert_key.tar.enc -out cert_key.tar -d


### PR DESCRIPTION
build matrix based on Phoenix: https://github.com/phoenixframework/phoenix/blob/master/.travis.yml

~~I'm seeing some strange behaviour with Pigeon, and trying to determine if upgrading to Erlang 19 is the reason.~~ (update: my strange issue was due to mocking things wrong)

Also, it couldn't hurt to be testing both versions of OTP.