### PR TITLE
Rename 'to' → 'name' in docs for APNS custom workers

### DIFF
--- a/docs/APNS Apple iOS.md
+++ b/docs/APNS Apple iOS.md
@@ -121,11 +121,11 @@ Multiple APNS worker connections can be configured simultaneously. Useful for su
     }
   ```
 
-Send pushes with a `to` option in your second parameter.
+Send pushes with a `name` option in your second parameter.
 
   ```elixir
   n = Pigeon.APNS.Notification.new("your message", "your device token", "your push topic")
-  Pigeon.APNS.push(n, to: :custom_worker)
+  Pigeon.APNS.push(n, name: :custom_worker)
   ```
 
 ## Asynchronous Pushing


### PR DESCRIPTION
According to https://github.com/codedge-llc/pigeon/blob/5cad838126aa8331a7f48256d06c308a957513c0/lib/pigeon/apns.ex#L36