### PR TITLE
HTTP2 support for FCM

### DIFF
--- a/lib/pigeon.ex
+++ b/lib/pigeon.ex
@@ -13,7 +13,7 @@ defmodule Pigeon do
   end
 
   defp workers do
-    adm_worker() ++ apns_workers()
+    adm_worker() ++ apns_workers() ++ gcm_workers()
   end
 
   def adm_worker do
@@ -35,6 +35,14 @@ defmodule Pigeon do
           config = Pigeon.APNS.Config.config(worker_name)
           worker(Pigeon.APNSWorker, [config], id: worker_name)
         end)
+      true -> []
+    end
+  end
+
+  defp gcm_workers do
+    cond do
+      config = Application.get_env(:pigeon, :gcm) ->
+        [worker(Pigeon.GCMWorker, [:gcm_worker, config], id: :gcm_worker)]
       true -> []
     end
   end

--- a/lib/pigeon/adm_worker.ex
+++ b/lib/pigeon/adm_worker.ex
@@ -241,4 +241,6 @@ defmodule Pigeon.ADMWorker do
       {:ok, registration_id}
     end
   end
+
+  def handle_info({_from, {:ok, %HTTPoison.Response{status_code: 200}}}, state), do: {:noreply, state}
 end

--- a/lib/pigeon/apns.ex
+++ b/lib/pigeon/apns.ex
@@ -31,13 +31,14 @@ defmodule Pigeon.APNS do
 
   defp do_sync_push(notification, opts) do
     pid = self()
-    on_response = fn(x) -> send pid, {:ok, x} end
+    ref = :erlang.make_ref
+    on_response = fn(x) -> send pid, {ref, x} end
 
     worker_name = opts[:name] || Config.default_name
     GenServer.cast(worker_name, {:push, :apns, notification, on_response})
 
     receive do
-      {:ok, x} -> x
+      {^ref, x} -> x
     after
       @default_timeout -> {:error, :timeout, notification}
     end

--- a/lib/pigeon/gcm.ex
+++ b/lib/pigeon/gcm.ex
@@ -22,8 +22,8 @@ defmodule Pigeon.GCM do
         Enum.foldl(notification, %{}, fn(n, acc) ->
           receive do
             {:ok, %NotificationResponse{message_id: id} = response} ->
-              if   Map.has_key? acc, id do
-                %{ acc | id => merge(response, acc[:message_id])}
+              if Map.has_key?(acc, id) do
+                %{acc | id => merge(response, acc[:message_id])}
               else
                 Map.merge(%{id => response}, acc)
               end
@@ -34,7 +34,6 @@ defmodule Pigeon.GCM do
       on_response -> send_push(notification, on_response, opts)
     end
   end
-
 
   def push(notification, opts) do
     case opts[:on_response] do
@@ -54,42 +53,38 @@ defmodule Pigeon.GCM do
     end
   end
 
-
   def encode_requests(%{registration_id: regid} = notification) when is_binary(regid) do
     encode_requests(%{notification | registration_id: [regid]})
   end
   def encode_requests(%{registration_id: regid} = notification) when length(regid) < 1001 do
-      res = recipient_attr(regid)
-      |> Map.merge(notification.payload)
-      |> Poison.encode!
-      formatted_regid = regid
-      |> List.wrap
-      [{  formatted_regid, res}]
+      res =
+        regid
+        |> recipient_attr()
+        |> Map.merge(notification.payload)
+        |> Poison.encode!
+        formatted_regid = regid
+        |> List.wrap
+
+      [{formatted_regid, res}]
   end
 
   def encode_requests(notification) do
       notification.registration_id
       |> Enum.chunk(1000, 1000, [])
-      |> Enum.map(fn(chunk) ->
-              encode_requests(%{notification | registration_id: chunk})
-            end)
+      |> Enum.map(& encode_requests(%{notification | registration_id: &1}))
       |> List.flatten
   end
 
-
   defp recipient_attr([regid]), do: %{"to" => regid}
   defp recipient_attr(regid) when is_list(regid), do: %{"registration_ids" => regid}
-
-
 
   @doc """
     Sends a push over GCM.
   """
   def send_push(notification, on_response, opts) do
-    encode_requests(notification)
-    |> Enum.map( fn(payload) ->
-          GenServer.cast(:gcm_worker, generate_envelope(payload, on_response, opts))
-        end)
+    notification
+    |> encode_requests()
+    |> Enum.map(& GenServer.cast(:gcm_worker, generate_envelope(&1, on_response, opts)))
   end
 
   def start_connection(name) do
@@ -105,19 +100,39 @@ defmodule Pigeon.GCM do
     Supervisor.delete_child(:pigeon, name)
   end
 
-  def generate_envelope payload, on_response, opts do
-    { :push, :gcm, payload, on_response, Map.new(opts)}
+  def generate_envelope(payload, on_response, opts) do
+    {:push, :gcm, payload, on_response, Map.new(opts)}
   end
 
+  # def merge(%NotificationResponse{ok: ok1,
+  #                                 retry: retry1,
+  #                                 update: update1,
+  #                                 remove: remove1,
+  #                                 error: error1}, %NotificationResponse{ok: ok2,
+  #                                                                       retry: retry2,
+  #                                                                       update: update2,
+  #                                                                       remove: remove2,
+  #                                                                       error: error2}) do
 
-  def merge %NotificationResponse{ok: ok1, retry: retry1, update: update1, remove: remove1, error: error1}, 
-                   %NotificationResponse{ok: ok2, retry: retry2, update: update2, remove: remove2, error: error2} do
-    error3 = Map.merge(error1, error2, fn(m, a, b) ->  a ++ b end)
-    %NotificationResponse{ok: ok1 ++ ok2, 
-                                          retry: retry1 ++ retry2, 
-                                          update: update1 ++ update2, 
-                                          remove: remove1 ++ remove2, 
-                                          error: error3}
+  #   error3 = Map.merge(error1, error2, fn(m, a, b) ->  a ++ b end)
+  #   %NotificationResponse{
+  #     ok: ok1 ++ ok2,
+  #     retry: retry1 ++ retry2,
+  #     update: update1 ++ update2,
+  #     remove: remove1 ++ remove2,
+  #     error: error3
+  #   }
+  # end
+
+  def merge(response_1, response_2) do
+    Map.merge(response_1, response_2, fn(key, value_1, value_2) ->
+      cond do
+        key == :__struct__ -> value_1
+        is_map(value_1) -> merge(value_1, value_2)
+        is_nil(value_1) -> value_2
+        is_nil(value_2) -> value_1
+        true -> value_1 ++ value_2
+      end
+    end)
   end
-
 end

--- a/lib/pigeon/gcm.ex
+++ b/lib/pigeon/gcm.ex
@@ -3,147 +3,121 @@ defmodule Pigeon.GCM do
   Handles all Google Cloud Messaging (GCM) request and response functionality.
   """
   require Logger
+  import Supervisor.Spec
 
-  # defp gcm_uri, do: 'https://gcm-http.googleapis.com/gcm/send'
-  defp gcm_uri, do: 'fcm.googleapis.com/fcm/send'
+  alias Pigeon.GCM.NotificationResponse
+  alias Pigeon.GCM.Notification
 
-  defp gcm_headers(key) do
-    [{ "Authorization", "key=#{key}" },
-     { "Content-Type", "application/json" },
-     { "Accept", "application/json" }]
-  end
+  @default_timeout 5_000
 
-  defp default_gcm_key, do: Application.get_env(:pigeon, :gcm)[:key]
-
-  @doc """
-  Sends a push over GCM
-  """
-  @spec push(Pigeon.GCM.Notification) :: none
-  def push(notification) do
-    do_push(notification, %{gcm_key: default_gcm_key()})
-  end
-
-  @doc """
-  Sends a push over GCM and executes function on success/failure.
-  """
-  @spec push(Pigeon.GCM.Notification, (() -> none)) :: none
-  def push(notification, on_response) when is_function(on_response) do
-    do_push(notification, %{gcm_key: default_gcm_key()}, on_response)
-  end
-
-  def push(notification, config, on_response \\ nil) do
-    do_push(notification, config, on_response)
-  end
-
-  defp do_push(notification, %{gcm_key: gcm_key}, on_response \\ nil) do
-    requests =
-      notification.registration_id
-      |> chunk_registration_ids
-      |> encode_requests(notification.payload)
-
-    response =
-      case on_response do
-        nil ->
-          fn({_reg_ids, payload}) ->
-            HTTPoison.post(gcm_uri(), payload, gcm_headers(gcm_key))
+  def push(notification, opts \\ [])
+  def push(notification, opts) when is_list(notification) do
+    case opts[:on_response] do
+      nil ->
+        for n <- notification do
+          pid = self()
+          on_response = fn(x) -> send pid, {:ok, x} end
+          send_push(n, on_response, opts)
+        end
+        Enum.foldl(notification, %{}, fn(n, acc) ->
+          receive do
+            {:ok, %NotificationResponse{message_id: id} = response} ->
+              if   Map.has_key? acc, id do
+                %{ acc | id => merge(response, acc[:message_id])}
+              else
+                Map.merge(%{id => response}, acc)
+              end
+          after 5_000 ->
+            acc
           end
-        _ ->
-          fn({reg_ids, payload}) ->
-            {:ok, %HTTPoison.Response{status_code: status, body: body}} =
-              HTTPoison.post(gcm_uri(), payload, gcm_headers(gcm_key))
-
-            notification = %{ notification | registration_id: reg_ids }
-            process_response(status, body, notification, on_response)
-          end
-      end
-    for r <- requests, do: Task.async(fn -> response.(r) end)
-    :ok
+        end)
+      on_response -> send_push(notification, on_response, opts)
+    end
   end
 
-  def chunk_registration_ids(reg_ids) when is_binary(reg_ids), do: [[reg_ids]]
-  def chunk_registration_ids(reg_ids), do: Enum.chunk(reg_ids, 1000, 1000, [])
 
-  def encode_requests([[reg_id]|_rest], payload) do
-    to_send = Map.merge(%{"to" => reg_id}, payload)
-    [{reg_id, Poison.encode!(to_send)}]
-  end
-  def encode_requests(registration_ids, payload) do
-    Enum.map(registration_ids, fn(x) -> encode_payload(x, payload) end)
+  def push(notification, opts) do
+    case opts[:on_response] do
+      nil -> do_sync_push(notification, opts)
+      on_response -> send_push(notification, on_response, opts)
+    end
   end
 
-  defp encode_payload(x, payload) do
-    encoded =
-      %{"registration_ids" => x}
-      |> Map.merge(payload)
+  defp do_sync_push(notification, opts) do
+    pid = self()
+    on_response = fn(x) -> send pid, {:ok, x} end
+    send_push(notification, on_response, opts)
+    receive do
+      {:ok, x} -> x
+    after
+      @default_timeout -> {:error, :timeout, notification}
+    end
+  end
+
+
+  def encode_requests(%{registration_id: regid} = notification) when is_binary(regid) do
+    encode_requests(%{notification | registration_id: [regid]})
+  end
+  def encode_requests(%{registration_id: regid} = notification) when length(regid) < 1001 do
+      res = recipient_attr(regid)
+      |> Map.merge(notification.payload)
       |> Poison.encode!
-    {x, encoded}
+      formatted_regid = regid
+      |> List.wrap
+      [{  formatted_regid, res}]
   end
 
-  def process_response(status, body, notification, on_response) do
-    case status do
-      200 ->
-        handle_200_status(body, notification, on_response)
-      400 ->
-        handle_error_status_code(:invalid_json, notification, on_response)
-      401 ->
-        handle_error_status_code(:authentication_error, notification, on_response)
-      500 ->
-        handle_error_status_code(:internal_server_error, notification, on_response)
-      _ ->
-        handle_error_status_code(:unknown_error, notification, on_response)
-    end
+  def encode_requests(notification) do
+      notification.registration_id
+      |> Enum.chunk(1000, 1000, [])
+      |> Enum.map(fn(chunk) ->
+              encode_requests(%{notification | registration_id: chunk})
+            end)
+      |> List.flatten
   end
 
-  def handle_error_status_code(reason, notification, on_response),
-    do: on_response.({:error, reason, notification})
 
-  def handle_200_status(body, %{registration_id: reg_id} = n, on_response) when is_list(reg_id) do
-    {:ok, json} = Poison.decode(body)
-    results = Enum.zip(n.registration_id, json["results"])
-    for result <- results, do: process_callback(result, n, on_response)
-  end
-  def handle_200_status(body, %{registration_id: _reg_id} = notification, on_response) do
-    {:ok, json} = Poison.decode(body)
-    results = Enum.zip([notification.registration_id], json["results"])
-    for result <- results, do: process_callback(result, notification, on_response)
-  end
+  defp recipient_attr([regid]), do: %{"to" => regid}
+  defp recipient_attr(regid) when is_list(regid), do: %{"registration_ids" => regid}
 
-  def process_callback({reg_id, response}, notification, on_response) do
-    case parse_result(response) do
-      {:ok, message_id} ->
-        notification = %{ notification | registration_id: reg_id, message_id: message_id }
-        on_response.({:ok, notification})
 
-      {:ok, message_id, registration_id} ->
-        notification =
-          %{ notification | registration_id: reg_id,
-          message_id: message_id,
-          updated_registration_id: registration_id }
-        on_response.({:ok, notification})
 
-      {:error, reason} ->
-        notification = %{ notification | registration_id: reg_id }
-        on_response.({:error, reason, notification})
-    end
+  @doc """
+    Sends a push over GCM.
+  """
+  def send_push(notification, on_response, opts) do
+    encode_requests(notification)
+    |> Enum.map( fn(payload) ->
+          GenServer.cast(:gcm_worker, generate_envelope(payload, on_response, opts))
+        end)
   end
 
-  def parse_result(result) do
-    error = result["error"]
-    if is_nil(error) do
-      parse_success(result)
-    else
-      error_atom = error |> Macro.underscore |> String.to_atom
-      {:error, error_atom}
-    end
+  def start_connection(name) do
+    config = %{
+      name: name,
+      gcm_key:  Application.get_env(:pigeon, :gcm)[:key]
+    }
+    Supervisor.start_child(:pigeon, worker(Pigeon.GCMWorker, [config], id: name))
   end
 
-  def parse_success(result) do
-    message_id = result["message_id"]
-    registration_id = result["registration_id"]
-    if is_nil(registration_id) do
-      {:ok, message_id}
-    else
-      {:ok, message_id, registration_id}
-    end
+  def stop_connection(name) do
+    Supervisor.terminate_child(:pigeon, name)
+    Supervisor.delete_child(:pigeon, name)
   end
+
+  def generate_envelope payload, on_response, opts do
+    { :push, :gcm, payload, on_response, Map.new(opts)}
+  end
+
+
+  def merge %NotificationResponse{ok: ok1, retry: retry1, update: update1, remove: remove1, error: error1}, 
+                   %NotificationResponse{ok: ok2, retry: retry2, update: update2, remove: remove2, error: error2} do
+    error3 = Map.merge(error1, error2, fn(m, a, b) ->  a ++ b end)
+    %NotificationResponse{ok: ok1 ++ ok2, 
+                                          retry: retry1 ++ retry2, 
+                                          update: update1 ++ update2, 
+                                          remove: remove1 ++ remove2, 
+                                          error: error3}
+  end
+
 end

--- a/lib/pigeon/gcm_worker.ex
+++ b/lib/pigeon/gcm_worker.ex
@@ -1,0 +1,234 @@
+defmodule Pigeon.GCMWorker do
+  @moduledoc """
+    Handles all APNS request and response parsing over an HTTP2 connection.
+  """
+  use GenServer
+  require Logger
+
+  alias Pigeon.GCM.NotificationResponse
+
+  @ping_period 600_000 # 10 minutes
+
+  defp gcm_uri(config), do: config[:endpoint] || 'fcm.googleapis.com'
+
+  def start_link(name, config) do
+    GenServer.start_link(__MODULE__, {:ok, config}, name: name)
+  end
+
+  def stop, do: :gen_server.cast(self(), :stop)
+
+  def init({:ok, config}), do: initialize_worker(config)
+
+  def initialize_worker(config) do
+    case connect_socket(config, 0) do
+      {:ok, socket} ->
+        Process.send_after(self(), :ping, @ping_period)
+        {:ok, %{
+          gcm_socket: socket,
+          key: config[:key],
+          stream_id: 1,
+          queue: %{}
+        }}
+      {:closed, _socket} ->
+        Logger.error """
+          Socket closed unexpectedly.
+          """
+        {:stop, {:error, :bad_connection}}
+      {:error, :timeout} ->
+        Logger.error """
+          Failed to establish SSL connection.
+          """
+        {:stop, {:error, :timeout}}
+      {:error, :invalid_config} ->
+        Logger.error """
+          Invalid configuration.
+          """
+        {:stop, {:error, :invalid_config}}
+    end
+  end
+
+  def connect_socket(_config, 3), do: {:error, :timeout}
+  def connect_socket(config, tries) do
+    uri = gcm_uri(config) |> to_char_list
+    case connect_socket_options(config) do
+      {:ok, options} -> do_connect_socket(config, uri, options, tries)
+      error -> error
+    end
+  end
+
+  def connect_socket_options(config) do
+      {:ok,  [
+        {:packet, 0},
+        {:reuseaddr, true},
+        {:active, true},
+        {:port, config[:port] || 443 },
+        :binary]
+      }
+  end
+
+
+  defp do_connect_socket(config, uri, options, tries) do
+    case Kadabra.open(uri, :https, options) do
+      {:ok, socket} -> {:ok, socket}
+      {:error, reason} ->
+        Logger.error(inspect(reason))
+        connect_socket(config, tries + 1)
+    end
+  end
+
+  def handle_cast(:stop, state), do: { :noreply, state }
+
+
+  def handle_cast({:push, :gcm, notification, on_response, %{gcm_key: key}}, state) do
+    send_push(state, notification, on_response, key)
+  end
+
+  def handle_cast({:push, :gcm, notification, on_response, _opts}, state) do
+    send_push(state, notification, on_response)
+  end
+
+  def handle_cast(msg, state) do
+    Logger.debug "Recv: #{inspect(msg)}"
+    {:noreply, state}
+  end
+
+  def send_push(%{key: key } = state, payload, on_response) do
+    send_push(state, payload, on_response, key)
+  end
+  
+  def send_push(%{gcm_socket: socket, stream_id: stream_id, queue: queue} = state, 
+      {registration_ids, payload}, on_response, key) do
+    req_headers = [
+      {":method", "POST"},
+      {":path", "/fcm/send"},
+      { "authorization", "key=#{key}" },
+      { "content-type", "application/json" },
+      { "accept", "application/json" }]
+    Kadabra.request(socket, req_headers, payload)
+
+    new_q = Map.put(queue, "#{stream_id}", {registration_ids, on_response})
+    new_stream_id = stream_id + 2
+    { :noreply, %{state | stream_id: new_stream_id, queue: new_q } }
+  end
+
+  defp parse_error(data) do
+    {:ok, response} = Poison.decode(data)
+    response["reason"] |> Macro.underscore |> String.to_existing_atom
+  end
+
+  defp log_error(code, reason) do
+    Logger.error("#{reason}: #{code}")
+  end
+
+
+  def handle_info(:ping, state) do
+    Kadabra.ping(state.gcm_socket)
+    Process.send_after(self(), :ping, @ping_period)
+
+    { :noreply, state }
+  end
+
+  def handle_info({:end_stream, %Kadabra.Stream{id: stream_id, headers: headers, body: body}},
+                                                %{gcm_socket: _socket, queue: queue} = state) do
+
+    {registration_ids, on_response} = queue["#{stream_id}"]
+    Logger.debug("#{inspect body} and #{inspect headers}")
+    case get_status(headers) do
+      "200" ->
+        result =  Poison.decode! body
+        parse_result(registration_ids, result, on_response)
+        new_queue = Map.delete(queue, "#{stream_id}")
+        {:noreply, %{state | queue: new_queue}}
+      nil ->
+        {:noreply, state}
+      "401" ->
+        log_error("401", "Unauthorized")
+        unless on_response == nil do on_response.({:error, :unauthorized}) end
+        new_queue = Map.delete(queue, "#{stream_id}")
+        {:noreply, %{state | queue: new_queue}}
+      "400" ->
+        log_error("400", "Malformed JSON")
+        unless on_response == nil do on_response.({:error, :malformed_json}) end
+        new_queue = Map.delete(queue, "#{stream_id}")
+        {:noreply, %{state | queue: new_queue}}
+      code ->
+        reason = parse_error(body)
+        log_error(code, reason)
+        unless on_response == nil do on_response.({:error, reason}) end
+        new_queue = Map.delete(queue, "#{stream_id}")
+        {:noreply, %{state | queue: new_queue}}
+    end
+  end
+
+  def handle_info({:ping, _from}, state), do: {:noreply, state}
+
+  def handle_info({:closed, _from}, state), do: {:noreply, state}
+
+  def handle_info({:ok, _from}, state), do: {:noreply, state}
+
+  # no on_response callback, ignore
+  def parse_result(_, _, nil), do: :ok
+
+  def parse_result(ids, %{"results" => results}, on_response) do
+    parse_result1(ids, results, on_response, %NotificationResponse{})
+  end
+
+  def parse_result1([], [], on_response, result) do
+    on_response.({:ok, result})
+  end
+
+  def parse_result1(regid, results, on_response, result) when is_binary(regid) do
+    parse_result1([regid], results, on_response, result)
+  end
+
+  def parse_result1([regid | reg_res], [%{"message_id" => id, "registration_id" => new_regid} | rest_results], on_response,
+      %NotificationResponse{ update: update} =  resp) do
+    new_updates = [ {regid, new_regid} | update ]
+    parse_result1(reg_res, rest_results, on_response, 
+      %{ resp | message_id: id, update: new_updates })
+  end
+
+  def parse_result1([regid | reg_res], [%{"message_id" => id} | rest_results], on_response,
+      %NotificationResponse{ok: ok} =  resp) do
+    parse_result1(reg_res, rest_results, on_response, 
+      %{ resp | message_id: id, ok: [ regid | ok] })
+  end
+
+  def parse_result1([regid | reg_res], [%{"error" => "Unavailable"} | rest_results], on_response, 
+      %NotificationResponse{retry: retry} = resp) do
+    parse_result1(reg_res, rest_results, on_response, 
+      %{ resp | retry: [ regid | retry] })
+  end
+
+  def parse_result1([regid | reg_res], [%{"error" => invalid } | rest_results], on_response, 
+      %NotificationResponse{remove: remove} =   resp )when invalid == "NotRegistered" or invalid == "InvalidRegistration" do
+    parse_result1(reg_res, rest_results, on_response, 
+      %{ resp | remove: [ regid | remove ] })
+  end
+
+  def parse_result1([regid | reg_res] = regs, [%{"error" => error} | rest_results] = results, on_response, 
+      %NotificationResponse{error: regs_in_error} = resp) do
+    case  Map.has_key? regs_in_error, error do
+      true -> 
+        parse_result1(reg_res, rest_results, on_response, 
+          %{ resp  | error: %{regs_in_error | error => regid  } })
+      false -> # create map key if required.
+         parse_result1(regs, results, on_response, 
+          %{ resp | error: Map.merge(%{error => []}, regs_in_error) })
+    end
+  end
+
+  
+  def parse_result1(regs, [%{"error" => error} | _r] = results, on_response, 
+      %NotificationResponse{error: errors} = resp) do
+   
+  end
+
+  defp get_status(headers) do
+    case Enum.find(headers, fn({key, _val}) -> key == ":status" end) do
+      {":status", status} -> status
+      nil -> nil
+    end
+  end
+
+end

--- a/lib/pigeon/notification.ex
+++ b/lib/pigeon/notification.ex
@@ -91,6 +91,14 @@ defmodule Pigeon.GCM.Notification do
   end
 end
 
+defmodule Pigeon.GCM.NotificationResponse do
+  @moduledoc """
+    Passed to the GCM on_response callback
+  """
+  defstruct message_id: nil, ok: [], retry: [], update: [], remove: [], error: %{}
+
+end
+
 defmodule Pigeon.ADM.Notification do
   @moduledoc """
     Defines Amazon ADM notification struct and convenience constructor functions.

--- a/lib/pigeon/notification.ex
+++ b/lib/pigeon/notification.ex
@@ -110,7 +110,8 @@ defmodule Pigeon.ADM.Notification do
     |> calculate_md5
   end
 
-  defp update_payload(notification, _key, value) when value == %{}, do: notification
+  defp update_payload(notification, key, value) when value == %{} and key != "data",
+    do: notification
   defp update_payload(notification, key, value) do
     payload =
       notification.payload
@@ -127,9 +128,7 @@ defmodule Pigeon.ADM.Notification do
     |> Enum.into(%{})
   end
 
-  def calculate_md5(notification) do
-    data = notification.payload["data"]
-
+  def calculate_md5(%{payload: %{"data" => data}} = notification) when is_map(data) do
     concat =
       data
       |> Map.keys
@@ -141,4 +140,5 @@ defmodule Pigeon.ADM.Notification do
 
     %{notification | md5: md5}
   end
+  def calculate_md5(notification), do: notification
 end

--- a/test/adm_notification_test.exs
+++ b/test/adm_notification_test.exs
@@ -4,7 +4,19 @@ defmodule Pigeon.ADMNotificationTest do
   def test_registration_id, do: "test1234"
   def test_data, do: %{ message: "your message" }
 
-  test "new" do
+  test "new/1" do
+    expected_result = %Pigeon.ADM.Notification{
+      registration_id: test_registration_id(),
+      payload: %{"data" => %{}},
+      updated_registration_id: nil,
+      consolidation_key: nil,
+      expires_after: 604800,
+      md5: "1B2M2Y8AsgTpgAmY7PhCfg=="
+    }
+    assert expected_result == Pigeon.ADM.Notification.new(test_registration_id())
+  end
+
+  test "new/2" do
     expected_result = %Pigeon.ADM.Notification{
       registration_id: test_registration_id(),
       payload: %{"data" => %{ "message" => "your message" }},

--- a/test/gcm_test.exs
+++ b/test/gcm_test.exs
@@ -1,79 +1,89 @@
 defmodule Pigeon.GCMTest do
   use ExUnit.Case
-
+  alias Pigeon.GCM.Notification
+  alias Pigeon.GCM.NotificationResponse
+  require Logger
   @data %{"message" => "Test push"}
   @payload %{"data" => @data}
 
   defp valid_gcm_reg_id, do: Application.get_env(:pigeon, :test)[:valid_gcm_reg_id]
 
   test "successfully sends a valid push" do
-    result =
+    {:ok, notification} =
       valid_gcm_reg_id()
-      |> Pigeon.GCM.Notification.new(%{}, @data)
+      |> Notification.new(%{}, @data)
       |> Pigeon.GCM.push
 
-    assert result == :ok
+    assert notification.ok == [valid_gcm_reg_id()]
+  end
+
+
+  test "Can merge two responses" do
+    nr1 = %NotificationResponse{ok: ["42"], retry: ["12"], error: %{"error" => ["1"] }}
+    nr2 = %NotificationResponse{ok: ["43"],  update: ["12"], error: %{"error" => ["2"], "error2"=> ["1"]} }
+    assert Pigeon.GCM.merge(nr1, nr2) == %NotificationResponse{ok: ["42", "43"], retry: ["12"],  update: ["12"],  error: %{"error" => ["1", "2"] , "error2" => ["1"]}}
+  end
+
+  test "Message for less than 1000 recipients should not be chunked" do
+    regs = Enum.to_list(1..999)
+    notification = Notification.new(regs,%{}, @data)
+    assert [{^regs, encoded}] = res = Pigeon.GCM.encode_requests(notification)
+  end
+
+  test "Message for over 1000 recipients should be chunked" do
+    regs = Enum.to_list(1..2534)
+    notification = Notification.new(regs,%{}, @data)
+    res = Pigeon.GCM.encode_requests(notification)
+    assert [{r1, e1}, {r2, e2}, {r3, e3}]  = res 
+    assert length(r1) == 1000
+    assert length(r2) == 1000
+    assert length(r3) == 534
   end
 
   test "successfully sends a valid push with an explicit config" do
-    result =
+    response =
       valid_gcm_reg_id()
-      |> Pigeon.GCM.Notification.new(%{}, @data)
-      |> Pigeon.GCM.push(%{gcm_key: System.get_env("GCM_KEY")})
+      |> Notification.new(%{}, @data)
+      |> Pigeon.GCM.push(%{gcm_key: "explicit"})
 
-    assert result == :ok
+     assert response == {:error, :unauthorized}
   end
 
   test "successfully sends a valid push with callback" do
     reg_id = valid_gcm_reg_id()
-    n = Pigeon.GCM.Notification.new(reg_id, %{}, @data)
+    n = Notification.new(reg_id, %{}, @data)
+    pid = self()
+    Pigeon.GCM.send_push(n, fn(x) -> send pid, x end, %{})
 
-    Pigeon.GCM.push(n, fn(x) -> send self(), x end)
-
-    assert_receive {_ref, [{:ok, notification}]}, 5000
-    assert notification.registration_id == reg_id
-    assert notification.payload == %{"data" => @data}
+    assert_receive {:ok, notification}, 5000
+    assert notification.ok == [reg_id]
   end
 
   test "returns an error on pushing with a bad registration_id" do
     reg_id = "bad_registration_id"
-    n = Pigeon.GCM.Notification.new(reg_id, %{}, @data)
+    n = Notification.new(reg_id, %{}, @data)
+    pid = self()
+    Pigeon.GCM.send_push(n, fn(x) -> send pid, x end, %{})
 
-    Pigeon.GCM.push(n, fn(x) -> send self(), x end)
-
-    assert_receive {_ref, [{:error, :invalid_registration, n}]}, 5000
+    assert_receive {:ok, %Pigeon.GCM.NotificationResponse{remove: ["bad_registration_id"]}}, 5000
     assert n.registration_id == reg_id
     assert n.payload == %{"data" => @data}
   end
 
-  test "parse_result with success" do
-    assert Pigeon.GCM.parse_result(%{ "message_id" => "1:0408" }) == {:ok, "1:0408"}
-  end
-
-  test "parse_result with success and new registration_id" do
-    assert Pigeon.GCM.parse_result(%{ "message_id" => "1:2342", "registration_id" => "32" }) ==
-      {:ok, "1:2342", "32"}
-  end
-
-  test "parse_result with error unavailable" do
-    assert Pigeon.GCM.parse_result(%{ "error" => "Unavailable" }) == {:error, :unavailable}
-  end
+  
 
   test "encode_requests with one registration_id" do
-    registration_id = [["123456"]]
-    assert Pigeon.GCM.encode_requests(registration_id, @payload) ==
-      [{"123456", ~S({"to":"123456","data":{"message":"Test push"}})}]
+    registration_id = "123456"
+    payload = Notification.new(registration_id, %{},@data)
+    assert Pigeon.GCM.encode_requests(payload) ==
+      [{["123456"], ~S({"to":"123456","data":{"message":"Test push"}})}]
   end
 
   test "encode_requests with multiple registration_ids" do
     registration_id = ["aaaaaa", "bbbbbb", "cccccc"]
+    payload = Notification.new(registration_id, %{},@data)
     expected = ~S({"registration_ids":["aaaaaa","bbbbbb","cccccc"],"data":{"message":"Test push"}})
-    assert Pigeon.GCM.encode_requests([registration_id], @payload) == [{registration_id, expected}]
+    assert Pigeon.GCM.encode_requests(payload) == [{registration_id, expected}]
   end
 
-  test "encode_requests with over 1000 registration_ids" do
-    reg_ids = Enum.chunk(Enum.to_list(1..2500), 1000, 1000, [])
-    result = Pigeon.GCM.encode_requests(reg_ids, @payload)
-    assert Enum.count(result) == 3
-  end
 end

--- a/test/gcm_test.exs
+++ b/test/gcm_test.exs
@@ -17,24 +17,37 @@ defmodule Pigeon.GCMTest do
     assert notification.ok == [valid_gcm_reg_id()]
   end
 
-
   test "Can merge two responses" do
-    nr1 = %NotificationResponse{ok: ["42"], retry: ["12"], error: %{"error" => ["1"] }}
-    nr2 = %NotificationResponse{ok: ["43"],  update: ["12"], error: %{"error" => ["2"], "error2"=> ["1"]} }
-    assert Pigeon.GCM.merge(nr1, nr2) == %NotificationResponse{ok: ["42", "43"], retry: ["12"],  update: ["12"],  error: %{"error" => ["1", "2"] , "error2" => ["1"]}}
+    nr1 = %NotificationResponse{
+      ok: ["42"],
+      retry: ["12"],
+      error: %{"error" => ["1"]}
+    }
+    nr2 = %NotificationResponse{
+      ok: ["43"],
+      update: ["12"],
+      error: %{"error" => ["2"], "error2"=> ["1"]}
+    }
+    assert Pigeon.GCM.merge(nr1, nr2) ==
+      %NotificationResponse{
+        ok: ["42", "43"],
+        retry: ["12"],
+        update: ["12"],
+        error: %{"error" => ["1", "2"] , "error2" => ["1"]}
+      }
   end
 
   test "Message for less than 1000 recipients should not be chunked" do
     regs = Enum.to_list(1..999)
-    notification = Notification.new(regs,%{}, @data)
+    notification = Notification.new(regs, %{}, @data)
     assert [{^regs, encoded}] = res = Pigeon.GCM.encode_requests(notification)
   end
 
   test "Message for over 1000 recipients should be chunked" do
     regs = Enum.to_list(1..2534)
-    notification = Notification.new(regs,%{}, @data)
+    notification = Notification.new(regs, %{}, @data)
     res = Pigeon.GCM.encode_requests(notification)
-    assert [{r1, e1}, {r2, e2}, {r3, e3}]  = res 
+    assert [{r1, e1}, {r2, e2}, {r3, e3}]  = res
     assert length(r1) == 1000
     assert length(r2) == 1000
     assert length(r3) == 534
@@ -69,8 +82,6 @@ defmodule Pigeon.GCMTest do
     assert n.registration_id == reg_id
     assert n.payload == %{"data" => @data}
   end
-
-  
 
   test "encode_requests with one registration_id" do
     registration_id = "123456"

--- a/test/gcm_worker_test.exs
+++ b/test/gcm_worker_test.exs
@@ -9,24 +9,46 @@ defmodule Pigeon.GCMWorkerTest do
   defp valid_gcm_reg_id, do: Application.get_env(:pigeon, :test)[:valid_gcm_reg_id]
 
   test "parse_result with success" do
-    {:ok, response} = GCMWorker.parse_result1(["regid"],[%{ "message_id" => "1:0408" }], &(&1), %NotificationResponse{})
+    {:ok, response} =
+      GCMWorker.parse_result1(
+        ["regid"],
+        [%{ "message_id" => "1:0408" }],
+        &(&1), %NotificationResponse{}
+      )
     assert  response.ok == ["regid"]
   end
 
   test "parse_result with success and new registration_id" do
-    {:ok, response} = GCMWorker.parse_result1(["regid"], [%{ "message_id" => "1:2342", "registration_id" => "32" }], &(&1), %NotificationResponse{})  
+    {:ok, response} =
+      GCMWorker.parse_result1(
+        ["regid"],
+        [%{ "message_id" => "1:2342", "registration_id" => "32" }],
+        &(&1), %NotificationResponse{}
+      )
 
     assert response.update == [{"regid", "32"}]
     assert response.message_id == "1:2342"
   end
 
   test "parse_result with error unavailable" do
-    {:ok, response} = GCMWorker.parse_result1(["regid"], [%{ "error" => "Unavailable" }], &(&1), %NotificationResponse{})
+    {:ok, response} =
+      GCMWorker.parse_result1(
+        ["regid"],
+        [%{ "error" => "Unavailable" }],
+        &(&1),
+        %NotificationResponse{}
+      )
     assert response.retry == ["regid"]
-  end 
+  end
 
-  test "parse_result with custom error" do 
-    {:ok, response} = GCMWorker.parse_result1(["regid"], [%{ "error" => "CustomError" }], &(&1), %NotificationResponse{})
+  test "parse_result with custom error" do
+    {:ok, response} =
+      GCMWorker.parse_result1(
+        ["regid"],
+        [%{ "error" => "CustomError" }],
+        &(&1),
+        %NotificationResponse{}
+      )
     assert response.error == %{"CustomError" => "regid"}
   end
 

--- a/test/gcm_worker_test.exs
+++ b/test/gcm_worker_test.exs
@@ -1,0 +1,41 @@
+defmodule Pigeon.GCMWorkerTest do
+  use ExUnit.Case
+  alias Pigeon.GCMWorker
+  alias Pigeon.GCM.NotificationResponse
+
+  @data %{"message" => "Test push"}
+  @payload %{"data" => @data}
+
+  defp valid_gcm_reg_id, do: Application.get_env(:pigeon, :test)[:valid_gcm_reg_id]
+
+  test "parse_result with success" do
+    {:ok, response} = GCMWorker.parse_result1(["regid"],[%{ "message_id" => "1:0408" }], &(&1), %NotificationResponse{})
+    assert  response.ok == ["regid"]
+  end
+
+  test "parse_result with success and new registration_id" do
+    {:ok, response} = GCMWorker.parse_result1(["regid"], [%{ "message_id" => "1:2342", "registration_id" => "32" }], &(&1), %NotificationResponse{})  
+
+    assert response.update == [{"regid", "32"}]
+    assert response.message_id == "1:2342"
+  end
+
+  test "parse_result with error unavailable" do
+    {:ok, response} = GCMWorker.parse_result1(["regid"], [%{ "error" => "Unavailable" }], &(&1), %NotificationResponse{})
+    assert response.retry == ["regid"]
+  end 
+
+  test "parse_result with custom error" do 
+    {:ok, response} = GCMWorker.parse_result1(["regid"], [%{ "error" => "CustomError" }], &(&1), %NotificationResponse{})
+    assert response.error == %{"CustomError" => "regid"}
+  end
+
+  test "send malformed JSON" do
+    {:ok, pid} = GCMWorker.start_link(:gonecrashing, key: Application.get_env(:pigeon, :gcm)[:key])
+    me = self()
+    :gen_server.cast(pid, {:push, :gcm, {"toto", "this is not json"}, &(send me, &1), %{}})
+    assert_receive {:error, :malformed_json}, 5000
+    :gen_server.cast(pid, :stop)
+  end
+
+end


### PR DESCRIPTION
Hi,

This is the initial proposal for supporting HTTP2 in FCM. I do not expect this PR to be perfect and mergeable; I have some questions ;)

## on_response
There are some breaking changes to parameters passed to on_response :
- it is now passed more values : 
`{:ok, [{:ok, id, regid}, {:retry, regid}, {:update, id, regid, newregid}]}`
It does not return the notification anymore. Usually the notification being send is available in the same scope the on_response handler is being sent. 
The `id` is the message id. I'm not sure we should return it. Is it useful? Given it also makes us handle more tuple arrities, I'm not sure it's a win.

- [x] update to NotificationReponse format

## things that are broken right now
- [x] handle over 1000 regids with automatic truncation — I'm wondering if it's really worth it, and tell the client to send batches of a 1000 more. That would simplify the on_response or sync call handling — only one message received.
- [x] custom configuration (per request GCM_KEY)

Tell me what you think.
