### PR TITLE
docs: docs for v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Add pigeon as a `mix.exs` dependency:
   end
   ```
   
-After running `mix deps.get`, configure `mix.exs` to start the application automatically.
+After running `mix deps.get`, if running Elixir `v1.3` or earlier, configure `mix.exs`
+to start the application automatically.
   ```elixir
   def application do
     [applications: [:pigeon]]

--- a/docs/APNS Apple iOS.md
+++ b/docs/APNS Apple iOS.md
@@ -105,7 +105,8 @@ Define custom payload data like so:
 
 ## Custom Worker Connections
 
-Multiple APNS worker connections can be configured simultaneously. Useful for supporting multiple apps and/or certificates at once.
+Multiple APNS worker connections can be configured simultaneously. Useful for supporting
+multiple apps and/or certificates at once.
 
   ```elixir
   config :pigeon, :apns,
@@ -128,6 +129,16 @@ Send pushes with a `to` option in your second parameter.
   Pigeon.APNS.push(n, to: :custom_worker)
   ```
 
+You can also start connections manually.
+
+  ```elixir
+  {:ok, pid} = Pigeon.APNS.start_connection(cert: "cert.pem", key: "key.pem", mode: :dev)
+  Pigeon.APNS.push(notif, to: pid)
+
+  Pigeon.APNS.start_connection(cert: "cert.pem", key: "key.pem", mode: :dev, name: :custom)
+  Pigeon.APNS.push(notif, to: :custom)
+  ```
+
 ## Asynchronous Pushing
 
 1. Pass an `on_response` option with an anonymous function in your second parameter.
@@ -137,7 +148,8 @@ Send pushes with a `to` option in your second parameter.
   Pigeon.APNS.push(n, on_response: fn(x) -> IO.inspect(x) end)
   ```
 
-2. Responses return a tuple of either `{:ok, notification}` or `{:error, reason, notification}`. You could handle responses like so:
+2. Responses return a tuple of either `{:ok, notification}` or `{:error, reason, notification}`.
+You could handle responses like so:
 
     ```elixir
   handler = fn(x) ->

--- a/docs/Getting Started.md
+++ b/docs/Getting Started.md
@@ -3,7 +3,7 @@
 ## Installation
 **Note: Pigeon's API will likely change until v1.0**
 
-Add pigeon and chatterbox as `mix.exs` dependencies:
+Add pigeon as a `mix.exs` dependency:
   ```elixir
   def deps do
     [
@@ -12,7 +12,8 @@ Add pigeon and chatterbox as `mix.exs` dependencies:
   end
   ```
   
-After running `mix deps.get`, configure `mix.exs` to start the application automatically.
+After running `mix deps.get`, if running Elixir `v1.3` or earlier, configure `mix.exs`
+to start the application automatically.
   ```elixir
   def application do
     [applications: [:pigeon]]

--- a/lib/pigeon/adm_worker.ex
+++ b/lib/pigeon/adm_worker.ex
@@ -242,5 +242,7 @@ defmodule Pigeon.ADMWorker do
     end
   end
 
-  def handle_info({_from, {:ok, %HTTPoison.Response{status_code: 200}}}, state), do: {:noreply, state}
+  def handle_info({_from, {:ok, %HTTPoison.Response{status_code: 200}}}, state) do
+    {:noreply, state}
+  end
 end

--- a/lib/pigeon/apns.ex
+++ b/lib/pigeon/apns.ex
@@ -6,7 +6,7 @@ defmodule Pigeon.APNS do
   require Logger
   import Supervisor.Spec
 
-  alias Pigeon.APNS.Config
+  alias Pigeon.APNS.{Config, Notification}
 
   @default_timeout 5_000
 
@@ -72,11 +72,13 @@ defmodule Pigeon.APNS do
   end
 
   @doc """
-    Sends a push over APNS.
+  Sends a push over APNS.
   """
+  @spec push([Notification.t], ((Notification.t) -> ()), Keyword.t) :: no_return
   def push(notification, on_response, opts) when is_list(notification) do
     for n <- notification, do: push(n, on_response, opts)
   end
+  @spec push(Notification.t, ((Notification.t) -> ()), Keyword.t) :: no_return
   def push(notification, on_response, opts) do
     worker_name = opts[:name] || Config.default_name
     GenServer.cast(worker_name, {:push, :apns, notification, on_response})

--- a/lib/pigeon/gcm.ex
+++ b/lib/pigeon/gcm.ex
@@ -63,7 +63,7 @@ defmodule Pigeon.GCM do
   def chunk_registration_ids(reg_ids) when is_binary(reg_ids), do: [[reg_ids]]
   def chunk_registration_ids(reg_ids), do: Enum.chunk(reg_ids, 1000, 1000, [])
 
-  def encode_requests([[reg_id]|_rest], payload) do
+  def encode_requests([[reg_id] | _rest], payload) do
     to_send = Map.merge(%{"to" => reg_id}, payload)
     [{reg_id, Poison.encode!(to_send)}]
   end

--- a/lib/pigeon/notification.ex
+++ b/lib/pigeon/notification.ex
@@ -1,6 +1,6 @@
 defmodule Pigeon.Notification do
   @moduledoc """
-    Contains shared functions for GCM and APNS.
+  Contains shared functions for GCM and APNS.
   """
   require Logger
 
@@ -17,37 +17,183 @@ end
 
 defmodule Pigeon.APNS.Notification do
   @moduledoc """
-    Defines APNS notification struct and convenience constructor functions.
+  Defines APNS notification struct and convenience constructor functions.
   """
   defstruct device_token: nil, payload: %{"aps" => %{}}, expiration: nil, topic: nil, id: nil
 
+  @type t :: %__MODULE__{
+    device_token: String.t,
+    expiration: String.t,
+    id: String.t,
+    payload: %{},
+    topic: String.t
+  }
+
+  @doc """
+  Returns an `APNS.Notification` struct with given message, device token, and
+  topic (optional).
+
+  Push payload is constructed in the form of `%{"aps" => %{"alert" => msg}}`
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.new("push message", "device token")
+      %Pigeon.APNS.Notification{
+        device_token: "device token",
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"alert" => "push message"}},
+        topic: nil
+      }
+  """
+  @spec new(String.t, String.t, String.t | nil) :: t
   def new(msg, token, topic \\ nil) do
     %Pigeon.APNS.Notification{
       device_token: token,
-      topic: topic,
-      payload: %{"aps" => %{"alert" => msg}}
+      payload: %{"aps" => %{"alert" => msg}},
+      topic: topic
     }
   end
 
+  @doc """
+  Returns an `APNS.Notification` struct with given message, device token,
+  topic, and message ID.
+
+  Push payload is constructed in the form of `%{"aps" => %{"alert" => msg}}`
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.new("push message", "device token", "topic", "id_1234")
+      %Pigeon.APNS.Notification{
+        device_token: "device token",
+        expiration: nil,
+        id: "id_1234",
+        payload: %{"aps" => %{"alert" => "push message"}},
+        topic: "topic" 
+      }
+  """
+  @spec new(String.t, String.t, String.t, String.t) :: t
   def new(msg, token, topic, id) do
     %Pigeon.APNS.Notification{
       device_token: token,
-      topic: topic,
+      id: id,
       payload: %{"aps" => %{"alert" => msg}},
-      id: id
+      topic: topic
     }
   end
 
+  @doc """
+  Updates `"alert"` key in push payload.
+  
+  This is the alert message displayed on the device.
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.put_alert(%Pigeon.APNS.Notification{}, "push message")
+      %Pigeon.APNS.Notification{
+        device_token: nil,
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"alert" => "push message"}},
+        topic: nil
+      }
+  """
+  @spec put_alert(t, String.t) :: t
   def put_alert(notification, alert), do: update_payload(notification, "alert", alert)
 
+  @doc """
+  Updates `"badge"` key in push payload.
+  
+  This is the badge number displayed on the application.
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.put_badge(%Pigeon.APNS.Notification{}, 5)
+      %Pigeon.APNS.Notification{
+        device_token: nil,
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"badge" => 5}},
+        topic: nil
+      }
+  """
+  @spec put_badge(t, integer) :: t
   def put_badge(notification, badge), do: update_payload(notification, "badge", badge)
 
+  @doc """
+  Updates `"sound"` key in push payload.
+
+  Used for custom notification sounds. Value should
+  be the name of the custom sound file in the application's binary.
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.put_sound(%Pigeon.APNS.Notification{}, "custom.aiff")
+      %Pigeon.APNS.Notification{
+        device_token: nil,
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"sound" => "custom.aiff"}},
+        topic: nil
+      }
+  """
+  @spec put_sound(t, String.t) :: t
   def put_sound(notification, sound), do: update_payload(notification, "sound", sound)
 
+  @doc """
+  Sets `"content-available"` flag in push payload.
+
+  Used for silent notifications. When set, ensure `alert`, `badge`, and `sound` keys
+  are not configured.
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.put_content_available(%Pigeon.APNS.Notification{})
+      %Pigeon.APNS.Notification{
+        device_token: nil,
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"content-available" => 1}},
+        topic: nil
+      }
+  """
+  @spec put_content_available(t) :: t
   def put_content_available(notification), do: update_payload(notification, "content-available", 1)
 
+  @doc """
+  Updates `"category"` key in push payload.
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.put_category(%Pigeon.APNS.Notification{}, "category")
+      %Pigeon.APNS.Notification{
+        device_token: nil,
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"category" => "category"}},
+        topic: nil
+      }
+  """
+  @spec put_category(t, String.t) :: t
   def put_category(notification, category), do: update_payload(notification, "category", category)
 
+  @doc """
+  Sets `"mutable-content"` flag in push payload.
+
+  Used for notification service extensions (such as displaying custom media).
+
+  ## Examples
+  
+      iex> Pigeon.APNS.Notification.put_mutable_content(%Pigeon.APNS.Notification{})
+      %Pigeon.APNS.Notification{
+        device_token: nil,
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"mutable-content" => 1}},
+        topic: nil
+      }
+  """
+  @spec put_mutable_content(t) :: t
   def put_mutable_content(notification), do: update_payload(notification, "mutable-content", 1)
 
   defp update_payload(notification, key, value) do
@@ -59,6 +205,22 @@ defmodule Pigeon.APNS.Notification do
     %{notification | payload: new_payload}
   end
 
+  @doc """
+  Puts custom data in push payload.
+
+  ## Examples
+  
+      iex> n = Pigeon.APNS.Notification.new("test message", "device token")
+      iex> Pigeon.APNS.Notification.put_custom(n, %{"custom-key" => 1234})
+      %Pigeon.APNS.Notification{
+        device_token: "device token",
+        expiration: nil,
+        id: nil,
+        payload: %{"aps" => %{"alert" => "test message"}, "custom-key" => 1234},
+        topic: nil
+      }
+  """
+  @spec put_custom(t, String.t) :: t
   def put_custom(notification, data) do
     new_payload = Map.merge(notification.payload, data)
     %{notification | payload: new_payload}
@@ -67,10 +229,50 @@ end
 
 defmodule Pigeon.GCM.Notification do
   @moduledoc """
-    Defines GCM notification struct and convenience constructor functions.
+  Defines GCM notification struct and convenience constructor functions.
   """
   defstruct registration_id: nil, payload: %{}, message_id: nil, updated_registration_id: nil
 
+  @type t :: %__MODULE__{
+    message_id: String.t,
+    payload: %{},
+    registration_id: String.t | [String.t],
+    updated_registration_id: String.t
+  }
+
+  @doc """
+  Creates `GCM.Notification` struct with device registration IDs and optional
+  notification and data payloads.
+
+  ## Examples
+  
+      iex> Pigeon.GCM.Notification.new("reg ID")
+      %Pigeon.GCM.Notification{
+        message_id: nil,
+        payload: %{},
+        registration_id: "reg ID",
+        updated_registration_id: nil
+      }
+
+      iex> Pigeon.GCM.Notification.new("reg ID", %{"body" => "test message"})
+      %Pigeon.GCM.Notification{
+        message_id: nil,
+        payload: %{"notification" => %{"body" => "test message"}},
+        registration_id: "reg ID",
+        updated_registration_id: nil
+      }
+
+      iex> Pigeon.GCM.Notification.new("reg ID", %{"body" => "test message"}, %{"key" => "value"})
+      %Pigeon.GCM.Notification{
+        message_id: nil,
+        payload: %{
+          "data" => %{"key" => "value"},
+          "notification" => %{"body" => "test message"}
+        },
+        registration_id: "reg ID",
+        updated_registration_id: nil
+      }
+  """
   def new(registration_ids, notification \\ %{}, data \\ %{})
   def new(registration_ids, notification, data) do
     %Pigeon.GCM.Notification{registration_id: registration_ids}
@@ -78,8 +280,34 @@ defmodule Pigeon.GCM.Notification do
     |> put_data(data)
   end
 
+  @doc """
+  Updates `"data"` key in push payload.
+
+  ## Examples
+
+      iex> Pigeon.GCM.Notification.put_data(%Pigeon.GCM.Notification{}, %{"key" => 1234})
+      %Pigeon.GCM.Notification{
+        message_id: nil,
+        payload: %{"data" => %{"key" => 1234}},
+        registration_id: nil,
+        updated_registration_id: nil
+      }
+  """
   def put_data(n, data), do: update_payload(n, "data", data)
 
+  @doc """
+  Updates `"notification"` key in push payload.
+
+  ## Examples
+
+      iex> Pigeon.GCM.Notification.put_notification(%Pigeon.GCM.Notification{}, %{"body" => "message"})
+      %Pigeon.GCM.Notification{
+        message_id: nil,
+        payload: %{"notification" => %{"body" => "message"}},
+        registration_id: nil,
+        updated_registration_id: nil
+      }
+  """
   def put_notification(n, notification), do: update_payload(n, "notification", notification)
 
   defp update_payload(notification, _key, value) when value == %{}, do: notification
@@ -93,17 +321,59 @@ end
 
 defmodule Pigeon.ADM.Notification do
   @moduledoc """
-    Defines Amazon ADM notification struct and convenience constructor functions.
+  Defines Amazon ADM notification struct and convenience constructor functions.
   """
   defstruct registration_id: nil, payload: %{}, updated_registration_id: nil,
             consolidation_key: nil, expires_after: 604800, md5: nil
 
+  @type t :: %__MODULE__{
+    consolidation_key: String.t,
+    expires_after: integer,
+    md5: binary,
+    payload: %{},
+    registration_id: String.t,
+    updated_registration_id: String.t
+  }
+
+  @doc """
+  Creates `ADM.Notification` struct with device registration ID and optional data payload.
+
+  ## Examples
+  
+      iex> Pigeon.ADM.Notification.new("reg ID", %{"message" => "your message"})
+      %Pigeon.ADM.Notification{
+        consolidation_key: nil,
+        md5: "qzF+HgArKZjJrpfcTbiFxg==",
+        payload: %{
+          "data" => %{"message" => "your message"}
+        },
+        registration_id: "reg ID",
+        updated_registration_id: nil
+      }
+  """
   def new(registration_id, data \\ %{})
   def new(registration_id, data) do
     %Pigeon.ADM.Notification{registration_id: registration_id}
     |> put_data(data)
   end
 
+  @doc """
+  Updates `"data"` key on push payload and calculates `md5` hash.
+
+  ## Examples
+  
+      iex> n = %Pigeon.ADM.Notification{}
+      iex> Pigeon.ADM.Notification.put_data(n, %{"message" => "your message"})
+      %Pigeon.ADM.Notification{
+        consolidation_key: nil,
+        md5: "qzF+HgArKZjJrpfcTbiFxg==",
+        payload: %{
+          "data" => %{"message" => "your message"}
+        },
+        registration_id: nil,
+        updated_registration_id: nil
+      }
+  """
   def put_data(n, data) do
     n
     |> update_payload("data", ensure_strings(data))
@@ -119,7 +389,7 @@ defmodule Pigeon.ADM.Notification do
   end
 
   @doc """
-    ADM requires that "data" keys and values are all strings
+  ADM requires that "data" keys and values are all strings.
   """
   def ensure_strings(data) do
     data
@@ -127,6 +397,9 @@ defmodule Pigeon.ADM.Notification do
     |> Enum.into(%{})
   end
 
+  @doc """
+  Calculates md5 hash of notification data payload.
+  """
   def calculate_md5(notification) do
     data = notification.payload["data"]
 

--- a/lib/pigeon/notification.ex
+++ b/lib/pigeon/notification.ex
@@ -340,6 +340,15 @@ defmodule Pigeon.ADM.Notification do
 
   ## Examples
   
+      iex> Pigeon.ADM.Notification.new("reg ID")
+      %Pigeon.ADM.Notification{
+        consolidation_key: nil,
+        md5: nil,
+        payload: %{},
+        registration_id: "reg ID",
+        updated_registration_id: nil
+      }
+
       iex> Pigeon.ADM.Notification.new("reg ID", %{"message" => "your message"})
       %Pigeon.ADM.Notification{
         consolidation_key: nil,

--- a/lib/pigeon/notification.ex
+++ b/lib/pigeon/notification.ex
@@ -300,7 +300,8 @@ defmodule Pigeon.GCM.Notification do
 
   ## Examples
 
-      iex> Pigeon.GCM.Notification.put_notification(%Pigeon.GCM.Notification{}, %{"body" => "message"})
+      iex> Pigeon.GCM.Notification.put_notification(%Pigeon.GCM.Notification{},
+      ...> %{"body" => "message"})
       %Pigeon.GCM.Notification{
         message_id: nil,
         payload: %{"notification" => %{"body" => "message"}},

--- a/test/adm_notification_test.exs
+++ b/test/adm_notification_test.exs
@@ -1,5 +1,6 @@
 defmodule Pigeon.ADMNotificationTest do
   use ExUnit.Case
+  doctest Pigeon.ADM.Notification
 
   def test_registration_id, do: "test1234"
   def test_data, do: %{ message: "your message" }

--- a/test/apns_test.exs
+++ b/test/apns_test.exs
@@ -1,5 +1,6 @@
 defmodule Pigeon.APNSTest do
   use ExUnit.Case
+  doctest Pigeon.APNS.Notification
 
   def test_message(msg), do: "#{DateTime.to_string(DateTime.utc_now())} - #{msg}"
   def test_topic, do: Application.get_env(:pigeon, :test)[:apns_topic]

--- a/test/gcm_test.exs
+++ b/test/gcm_test.exs
@@ -1,5 +1,6 @@
 defmodule Pigeon.GCMTest do
   use ExUnit.Case
+  doctest Pigeon.GCM.Notification
 
   @data %{"message" => "Test push"}
   @payload %{"data" => @data}


### PR DESCRIPTION
Still WIP

@talklittle I'm guessing I got the ADM.Notification docs correct. I noticed in my doctests that ADM's `new/2` fails when data is `nil`. I don't know if there is a reason you would ever send a push without a data payload, but it should either be fixed or made non-optional.