### PR TITLE
feat: configurable ping period (closes #60)

### DIFF
--- a/lib/pigeon/apns.ex
+++ b/lib/pigeon/apns.ex
@@ -96,7 +96,8 @@ defmodule Pigeon.APNS do
       cert: Config.cert(opts[:cert]),
       certfile: Config.file_path(opts[:cert]),
       key: Config.key(opts[:key]),
-      keyfile: Config.file_path(opts[:key])
+      keyfile: Config.file_path(opts[:key]),
+      ping_period: opts[:ping_period] || 600_000
     }
     Pigeon.APNSWorker.start_link(config)
   end

--- a/lib/pigeon/apns_config.ex
+++ b/lib/pigeon/apns_config.ex
@@ -14,7 +14,8 @@ defmodule Pigeon.APNS.Config do
       certfile: file_path(config[:cert]),
       key: key(config[:key]),
       keyfile: file_path(config[:key]),
-      use_2197: config[:use_2197] || false
+      use_2197: config[:use_2197] || false,
+      ping_period: config[:ping_period] || 600_000
     }
   end
 

--- a/lib/pigeon/apns_worker.ex
+++ b/lib/pigeon/apns_worker.ex
@@ -1,11 +1,9 @@
 defmodule Pigeon.APNSWorker do
   @moduledoc """
-    Handles all APNS request and response parsing over an HTTP2 connection.
+  Handles all APNS request and response parsing over an HTTP2 connection.
   """
   use GenServer
   require Logger
-
-  @ping_period 600_000 # 10 minutes
 
   defp apns_production_api_uri, do: "api.push.apple.com"
   defp apns_development_api_uri, do: "api.development.push.apple.com"
@@ -32,7 +30,7 @@ defmodule Pigeon.APNSWorker do
     mode = config[:mode]
     case connect_socket(config, 0) do
       {:ok, socket} ->
-        Process.send_after(self(), :ping, @ping_period)
+        Process.send_after(self(), :ping, config[:ping_period])
         {:ok, %{
           apns_socket: socket,
           mode: mode,
@@ -263,7 +261,7 @@ defmodule Pigeon.APNSWorker do
 
   def handle_info(:ping, state) do
     Pigeon.Http2.Client.default().send_ping(state.apns_socket)
-    Process.send_after(self(), :ping, @ping_period)
+    Process.send_after(self(), :ping, state.config.ping_period)
 
     {:noreply, state}
   end

--- a/lib/pigeon/http2_client/kadabra.ex
+++ b/lib/pigeon/http2_client/kadabra.ex
@@ -2,21 +2,15 @@ defmodule Pigeon.Http2.Client.Kadabra do
   @behaviour Pigeon.Http2.Client
 
   def connect(uri, scheme, opts) do
-    if Code.ensure_loaded?(Kadabra) do
-      Kadabra.open(uri, scheme, opts)
-    end
+    Kadabra.open(uri, scheme, opts)
   end
 
   def send_request(pid, headers, data) do
-    if Code.ensure_loaded?(Kadabra) do
-      Kadabra.request(pid, headers, data)
-    end
+    Kadabra.request(pid, headers, data)
   end
 
   def send_ping(pid) do
-    if Code.ensure_loaded?(Kadabra) do
-      Kadabra.ping(pid)
-    end
+    Kadabra.ping(pid)
   end
 
   def handle_end_stream({:end_stream, %{id: id,

--- a/test/apns_test.exs
+++ b/test/apns_test.exs
@@ -19,8 +19,25 @@ defmodule Pigeon.APNSTest do
       {:ok, pid} = Pigeon.APNS.start_connection(opts)
       assert is_pid(pid)
 
+      state = :sys.get_state(pid)
+      assert state.mode == :dev
+      assert state.config.ping_period == 600_000
+
       {:ok, pid} = Pigeon.APNS.start_connection(opts)
       assert is_pid(pid)
+    end
+
+    test "configures ping_period if specified" do
+      opts = [
+        cert: Application.get_env(:pigeon, :test)[:apns_cert],
+        key: Application.get_env(:pigeon, :test)[:apns_key],
+        mode: :dev,
+        ping_period: 30_000
+      ]
+
+      {:ok, pid} = Pigeon.APNS.start_connection(opts)
+      state = :sys.get_state(pid)
+      assert state.config.ping_period == 30_000
     end
   end
 
@@ -82,7 +99,7 @@ defmodule Pigeon.APNSTest do
         mode: :dev,
         name: :custom
       ]
-      {:ok, worker_pid} = Pigeon.APNS.start_connection(opts)
+      {:ok, _worker_pid} = Pigeon.APNS.start_connection(opts)
 
       assert {:ok, _notif} = Pigeon.APNS.push(n, to: :custom)
 
@@ -186,7 +203,7 @@ defmodule Pigeon.APNSTest do
         mode: :dev,
         name: :custom
       ]
-      {:ok, worker_pid} = Pigeon.APNS.start_connection(opts)
+      {:ok, _worker_pid} = Pigeon.APNS.start_connection(opts)
 
       assert Pigeon.APNS.push(n, on_response: on_response, to: :custom) == :ok
 


### PR DESCRIPTION
Can now be configured on a per-worker basis. Time specified in ms. Defaults to 10 minutes. @asgoel 

```elixir
config :pigeon, :apns,
  default: %{
    cert: "cert.pem",
    key: "key_unencrypted.pem",
    mode: :dev,
    ping_period: 300_000
  }

## OR ##

{:ok, pid} = Pigeon.APNS.start_connection(ping_period: 300_000)
```
