### PR TITLE
feat: allow reconnect to be configured

### DIFF
--- a/lib/pigeon/apns_config.ex
+++ b/lib/pigeon/apns_config.ex
@@ -10,6 +10,7 @@ defmodule Pigeon.APNS.Config do
     %{
       name: name,
       mode: config[:mode],
+      reconnect: Map.get(config, :reconnect, true),
       cert: cert(config[:cert]),
       certfile: file_path(config[:cert]),
       key: key(config[:key]),

--- a/test/apns_worker_test.exs
+++ b/test/apns_worker_test.exs
@@ -28,6 +28,7 @@ defmodule Pigeon.APNSWorkerTest do
       {:ok, %{
         apns_socket: _socket,
         mode: mode,
+        reconnect: true,
         config: config,
         stream_id: stream_id,
         queue: _queue


### PR DESCRIPTION
This comes from a real-world use case of ours where we have implemented our own retry mechanism with a back-off feature. One of the certs was invalid causing an endless loop of:

 > 13:45:09.064 [error] Got GOAWAY, NO_ERROR, Last Stream: 0, Rest: {"reason":"BadCertificateEnvironment"}

Although Kadabra supports reconnects, there doesn't seem to be a way to disable it from within Pigeon.