### PR TITLE
fix: GOAWAY session_timed_out (closes #81)

### DIFF
--- a/lib/pigeon/fcm/worker.ex
+++ b/lib/pigeon/fcm/worker.ex
@@ -137,10 +137,8 @@ defmodule Pigeon.FCM.Worker do
 
     Pigeon.Http2.Client.default().send_request(state.socket, req_headers, payload)
 
-    IO.inspect(state, label: "fcm state")
-
-    new_q = Map.put(queue, "#{stream_id}", {registration_ids, on_response})
-    new_stream_id = stream_id + 2
+    new_q = Map.put(queue, "#{state.stream_id}", {registration_ids, on_response})
+    new_stream_id = state.stream_id + 2
     {:noreply, %{state | stream_id: new_stream_id, queue: new_q}}
   end
 

--- a/lib/pigeon/fcm/worker.ex
+++ b/lib/pigeon/fcm/worker.ex
@@ -114,7 +114,7 @@ defmodule Pigeon.FCM.Worker do
     send_push(state, payload, on_response, key)
   end
 
-  def send_push(%{socket: socket, stream_id: stream_id, queue: queue} = state,
+  def send_push(%{socket: socket, queue: queue} = state,
                 {registration_ids, payload},
                 on_response,
                 key) do
@@ -148,7 +148,7 @@ defmodule Pigeon.FCM.Worker do
         Process.send_after(self(), :ping, config.ping_period)
         {:ok, %{state | socket: new_socket, queue: %{}, stream_id: 1}}
       error ->
-        IO.inspect(error, label: "reconnect error")
+        error |> inspect() |> Logger.error
         {:error, state}
     end
   end
@@ -173,8 +173,7 @@ defmodule Pigeon.FCM.Worker do
 
   def handle_info({:ping, _from}, state), do: {:noreply, state}
 
-  def handle_info({:closed, _from}, %{config: config} = state) do
-    Logger.info "FCM client closed due to probable session_timed_out GOAWAY error)"
+  def handle_info({:closed, _from}, state) do
     {:noreply, %{state | socket: nil}}
   end
 

--- a/lib/pigeon/fcm/worker.ex
+++ b/lib/pigeon/fcm/worker.ex
@@ -122,7 +122,7 @@ defmodule Pigeon.FCM.Worker do
       case connect_socket(config, 0) do
         {:ok, new_socket} ->
           Process.send_after(self(), :ping, config.ping_period)
-          state = Map.put(config, :socket, new_socket)
+          state = Map.put(state, :socket, new_socket)
         error ->
           IO.inspect(error, label: "reconnect error")
           :error

--- a/mix.exs
+++ b/mix.exs
@@ -31,7 +31,7 @@ defmodule Pigeon.Mixfile do
   defp deps do
     [{:poison, "~> 2.0 or ~> 3.0"},
     {:httpoison, "~> 0.7"},
-    {:kadabra, "~> 0.2.0", optional: true},
+    {:kadabra, "~> 0.2.1", optional: true},
     {:dogma, "~> 0.1", only: :dev},
     {:earmark, "~> 1.0", only: :dev},
     {:ex_doc, "~> 0.2", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pigeon.Mixfile do
   def project do
     [app: :pigeon,
      name: "Pigeon",
-     version: "1.0.1",
+     version: "1.0.2",
      elixir: "~> 1.2",
      source_url: "https://github.com/codedge-llc/pigeon",
      description: description(),

--- a/test/fcm/worker_test.exs
+++ b/test/fcm/worker_test.exs
@@ -3,6 +3,10 @@ defmodule Pigeon.FCM.WorkerTest do
 
   alias Pigeon.FCM
 
+  defp valid_fcm_reg_id do
+    Application.get_env(:pigeon, :test)[:valid_fcm_reg_id]
+  end
+
   test "send malformed JSON" do
     opts = [
       name: :gonecrashing,
@@ -16,5 +20,41 @@ defmodule Pigeon.FCM.WorkerTest do
     assert_receive {:error, :malformed_json}, 5000
 
     :gen_server.cast(pid, :stop)
+  end
+
+  test "reconnects on push send after disconnect" do
+    opts = [
+      key: Application.get_env(:pigeon, :test)[:fcm_key]
+    ]
+    {:ok, pid} = FCM.start_connection(opts)
+    send(pid, {:closed, self()})
+
+    refute :sys.get_state(pid).socket
+
+    n = FCM.Notification.new(valid_fcm_reg_id(), %{}, %{"message" => "Test push"})
+    assert {:ok, _notif} = Pigeon.FCM.push(n, to: pid)
+
+    assert :sys.get_state(pid).socket
+  end
+
+  test "resets stream id after disconnect" do
+    opts = [
+      key: Application.get_env(:pigeon, :test)[:fcm_key]
+    ]
+    {:ok, pid} = FCM.start_connection(opts)
+
+    n = FCM.Notification.new(valid_fcm_reg_id(), %{}, %{"message" => "Test push"})
+    assert {:ok, _notif} = Pigeon.FCM.push(n, to: pid)
+    assert {:ok, _notif} = Pigeon.FCM.push(n, to: pid)
+    assert {:ok, _notif} = Pigeon.FCM.push(n, to: pid)
+
+    send(pid, {:closed, self()})
+    assert :sys.get_state(pid).stream_id == 7
+
+    n = FCM.Notification.new(valid_fcm_reg_id(), %{}, %{"message" => "Test push"})
+    assert {:ok, _notif} = Pigeon.FCM.push(n, to: pid)
+    assert {:ok, _notif} = Pigeon.FCM.push(n, to: pid)
+
+    assert :sys.get_state(pid).stream_id == 5
   end
 end


### PR DESCRIPTION
Reconnects FCM socket only on subsequent pushes after a disconnect. Prevents infinite reconnect loop.