### PR TITLE
fix: proper handling of large FCM push batches

### DIFF
--- a/lib/pigeon/apns/config.ex
+++ b/lib/pigeon/apns/config.ex
@@ -9,7 +9,7 @@ defmodule Pigeon.APNS.Config do
     config = Application.get_env(:pigeon, :apns)[name]
     %{
       name: name,
-      mode: config[:mode],
+      mode: mode(config[:mode]),
       reconnect: Map.get(config, :reconnect, true),
       cert: cert(config[:cert]),
       certfile: file_path(config[:cert]),
@@ -19,6 +19,16 @@ defmodule Pigeon.APNS.Config do
       ping_period: config[:ping_period] || 600_000
     }
   end
+
+  def mode({:system, env_var}), do: to_mode(System.get_env(env_var))
+  def mode(mode), do: mode
+
+  def to_mode(nil), do: raise "APNS.Config mode is nil"
+  def to_mode("dev"), do: :dev
+  def to_mode(":dev"), do: :dev
+  def to_mode("prod"), do: :prod
+  def to_mode(":prod"), do: :prod
+  def to_mode(other), do: raise "APNS.Config mode is #{inspect(other)}"
 
   def file_path(nil), do: nil
   def file_path(path) when is_binary(path) do

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -80,9 +80,17 @@ defmodule Pigeon.FCM do
   end
   def encode_requests(notification) do
     notification.registration_id
-    |> Enum.chunk_every(@chunk_size, @chunk_size, [])
+    |> chunk(@chunk_size, @chunk_size, [])
     |> Enum.map(& encode_requests(%{notification | registration_id: &1}))
     |> List.flatten
+  end
+
+  defp chunk(collection, chunk_size, step, padding) do
+    if Kernel.function_exported?(Enum, :chunk_every, 4) do
+      Enum.chunk_every(collection, chunk_size, step, padding)
+    else
+      Enum.chunk(collection, chunk_size, step, padding)
+    end
   end
 
   defp recipient_attr([regid]), do: %{"to" => regid}

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -5,42 +5,49 @@ defmodule Pigeon.FCM do
   require Logger
   import Supervisor.Spec
 
-  alias Pigeon.FCM.NotificationResponse
+  alias Pigeon.FCM.{Notification, NotificationResponse}
 
   @default_timeout 5_000
   @default_worker :fcm_default
+  @chunk_size 1_000
 
+  @spec push(Notification.t, Keyword.t) :: {:ok, NotificationResponse.t}
+  @spec push([Notification.t, ...], Keyword.t) :: [NotificationResponse.t, ...]
   def push(notification, opts \\ [])
   def push(notification, opts) when is_list(notification) do
     case opts[:on_response] do
       nil ->
-        ref = :erlang.make_ref
-        pid = self()
-        for n <- notification do
-          on_response = fn(x) -> send pid, {ref, x} end
-          send_push(n, on_response, opts)
-        end
-        Enum.foldl(notification, %{}, fn(_n, acc) ->
-          receive do
-            {^ref, %NotificationResponse{message_id: id} = response} ->
-              if Map.has_key?(acc, id) do
-                %{acc | id => merge(response, acc[:message_id])}
-              else
-                Map.merge(%{id => response}, acc)
-              end
-          after 5_000 ->
-            acc
-          end
-        end)
-      on_response -> send_push(notification, on_response, opts)
+        tasks = for n <- notification, do: Task.async(fn -> do_sync_push(n, opts) end)
+        tasks
+        |> Task.yield_many(@default_timeout + 10_000)
+        |> Enum.map(&task_mapper(&1))
+      on_response ->
+        for n <- notification, do: send_push(n, on_response, opts)
     end
   end
-
   def push(notification, opts) do
     case opts[:on_response] do
       nil -> do_sync_push(notification, opts)
       on_response -> send_push(notification, on_response, opts)
     end
+  end
+
+  defp task_mapper({task, result}) do
+    case result do
+      nil -> Task.shutdown(task, :brutal_kill)
+      {:ok, {:ok, response}} -> {:ok, response}
+      {:ok, {:error, :timeout, notification}} -> {:error, notification}
+    end
+  end
+
+  @doc """
+  Sends a push over FCM.
+  """
+  def send_push(notification, on_response, opts) do
+    worker_name = opts[:to] || @default_worker
+    notification
+    |> encode_requests()
+    |> Enum.map(& GenServer.cast(worker_name, generate_envelope(&1, on_response, opts)))
   end
 
   defp do_sync_push(notification, opts) do
@@ -73,23 +80,13 @@ defmodule Pigeon.FCM do
   end
   def encode_requests(notification) do
     notification.registration_id
-    |> Enum.chunk(1000, 1000, [])
+    |> Enum.chunk_every(@chunk_size, @chunk_size, [])
     |> Enum.map(& encode_requests(%{notification | registration_id: &1}))
     |> List.flatten
   end
 
   defp recipient_attr([regid]), do: %{"to" => regid}
   defp recipient_attr(regid) when is_list(regid), do: %{"registration_ids" => regid}
-
-  @doc """
-  Sends a push over FCM.
-  """
-  def send_push(notification, on_response, opts) do
-    worker_name = opts[:to] || @default_worker
-    notification
-    |> encode_requests()
-    |> Enum.map(& GenServer.cast(worker_name, generate_envelope(&1, on_response, opts)))
-  end
 
   def start_connection(opts \\ [])
   def start_connection(name) when is_atom(name) do
@@ -121,7 +118,8 @@ defmodule Pigeon.FCM do
         is_map(value_1) -> merge(value_1, value_2)
         is_nil(value_1) -> value_2
         is_nil(value_2) -> value_1
-        true -> value_1 ++ value_2
+        is_list(value_1) && is_list(value_2) -> value_1 ++ value_2
+        true -> [value_1] ++ [value_2]
       end
     end)
   end

--- a/lib/pigeon/http2_client/kadabra.ex
+++ b/lib/pigeon/http2_client/kadabra.ex
@@ -15,9 +15,10 @@ defmodule Pigeon.Http2.Client.Kadabra do
 
   def handle_end_stream({:end_stream, %{id: id,
                                         headers: headers,
-                                        body: body}}, _state) do
+                                        body: body,
+                                        error: error}}, _state) do
 
-    {:ok, %Pigeon.Http2.Stream{id: id, headers: headers, body: body}}
+    {:ok, %Pigeon.Http2.Stream{id: id, headers: headers, body: body, error: error}}
   end
   def handle_end_stream(msg, _state), do: msg
 end

--- a/lib/pigeon/http2_stream.ex
+++ b/lib/pigeon/http2_stream.ex
@@ -1,3 +1,3 @@
 defmodule Pigeon.Http2.Stream do
-  defstruct id: nil, headers: nil, body: nil
+  defstruct id: nil, headers: nil, body: nil, error: nil
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pigeon.Mixfile do
   def project do
     [app: :pigeon,
      name: "Pigeon",
-     version: "1.0.2",
+     version: "1.0.3",
      elixir: "~> 1.2",
      source_url: "https://github.com/codedge-llc/pigeon",
      description: description(),
@@ -31,7 +31,7 @@ defmodule Pigeon.Mixfile do
   defp deps do
     [{:poison, "~> 2.0 or ~> 3.0"},
     {:httpoison, "~> 0.7"},
-    {:kadabra, "~> 0.2.1", optional: true},
+    {:kadabra, "~> 0.2.2", optional: true},
     {:dogma, "~> 0.1", only: :dev},
     {:earmark, "~> 1.0", only: :dev},
     {:ex_doc, "~> 0.2", only: :dev},

--- a/test/fcm_test.exs
+++ b/test/fcm_test.exs
@@ -49,7 +49,7 @@ defmodule Pigeon.FCMTest do
       ]
       {:ok, worker_pid} = Pigeon.FCM.start_connection(opts)
 
-      assert {:ok, notif} = Pigeon.FCM.push(n, to: worker_pid)
+      assert {:ok, _notif} = Pigeon.FCM.push(n, to: worker_pid)
     end
 
     test "pushes to worker's atom name" do

--- a/test/fcm_test.exs
+++ b/test/fcm_test.exs
@@ -49,7 +49,7 @@ defmodule Pigeon.FCMTest do
       ]
       {:ok, worker_pid} = Pigeon.FCM.start_connection(opts)
 
-      assert {:ok, _notif} = Pigeon.FCM.push(n, to: worker_pid)
+      assert {:ok, notif} = Pigeon.FCM.push(n, to: worker_pid)
     end
 
     test "pushes to worker's atom name" do


### PR DESCRIPTION
FCM Issues Fixed:
- Sending too many pushes at once (now obeys `max_concurrent_streams`)
- Sending a lot of RegID's in one notification (proper `DATA` frame chunking)
- Synchronous response waiting for multiple `FCM.Notification` structs

Note:
Sending a huge batch of synchronous pushes may take longer than the timeout (15secs). Passing an `:on_response` callback is recommended.