### PR TITLE
fix: disabled pings for FCM.Worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## v1.0.4
+* Fix: removed connection pinging from FCM.Worker (`:ping_period` option left in FCM config to not break API)
+
+## v1.0.3
+* Fixed proper handling of large FCM push batches
+
+## v1.0.2
+* Fixed FCM infinite `GOAWAY session_timed_out` loop
+
 ## v1.0.2
 * Fixed FCM infinite `GOAWAY session_timed_out` loop
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,6 @@
 ## v1.0.2
 * Fixed FCM infinite `GOAWAY session_timed_out` loop
 
-## v1.0.2
-* Fixed FCM infinite `GOAWAY session_timed_out` loop
-
 ## v1.0.1
 * Configurable `:ping_period` for FCM connections
 

--- a/lib/pigeon/adm.ex
+++ b/lib/pigeon/adm.ex
@@ -12,9 +12,15 @@ defmodule Pigeon.ADM do
   @spec push(Notification.t, Keyword.t) :: none
   def push(notification, opts \\ []) do
     worker_name = opts[:to] || Config.default_name
-    case opts[:on_response] do
-      nil -> GenServer.cast(worker_name, {:push, :adm, notification})
-      on_response -> GenServer.cast(worker_name, {:push, :adm, notification, on_response})
-    end
+    GenServer.cast(worker_name, {:push, :adm, notification})
+  end
+
+  @doc """
+    Sends a push over ADM.
+  """
+  @spec push(Notification.t, (() -> none), Keyword.t) :: none
+  def push(notification, on_response, opts) do
+    worker_name = opts[:to] || Config.default_name
+    GenServer.cast(worker_name, {:push, :adm, notification, on_response})
   end
 end

--- a/lib/pigeon/fcm/worker.ex
+++ b/lib/pigeon/fcm/worker.ex
@@ -30,7 +30,6 @@ defmodule Pigeon.FCM.Worker do
       {:ok, socket} ->
         ping = config[:ping_period] || @default_ping_period
         config = Map.put(config, :ping_period, ping)
-        Process.send_after(self(), :ping, ping)
 
         {:ok, %{
           socket: socket,
@@ -145,7 +144,6 @@ defmodule Pigeon.FCM.Worker do
   def reconnect(%{config: config} = state) do
     case connect_socket(config, 0) do
       {:ok, new_socket} ->
-        Process.send_after(self(), :ping, config.ping_period)
         {:ok, %{state | socket: new_socket, queue: %{}, stream_id: 1}}
       error ->
         error |> inspect() |> Logger.error
@@ -165,7 +163,6 @@ defmodule Pigeon.FCM.Worker do
   def handle_info(:ping, state) do
     if state.socket != nil do
       Pigeon.Http2.Client.default().send_ping(state.socket)
-      Process.send_after(self(), :ping, state.config.ping_period)
     end
 
     {:noreply, state}

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pigeon.Mixfile do
   def project do
     [app: :pigeon,
      name: "Pigeon",
-     version: "1.0.3",
+     version: "1.0.4",
      elixir: "~> 1.2",
      source_url: "https://github.com/codedge-llc/pigeon",
      description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -9,7 +9,7 @@
   "httpoison": {:hex, :httpoison, "0.13.0", "bfaf44d9f133a6599886720f3937a7699466d23bb0cd7a88b6ba011f53c6f562", [], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jsx": {:hex, :jsx, "2.8.2", "7acc7d785b5abe8a6e9adbde926a24e481f29956dd8b4df49e3e4e7bcc92a018", [], [], "hexpm"},
-  "kadabra": {:hex, :kadabra, "0.2.2", "4e1d19ca6dd8df3171088f6ca9839039cab28c1fd9892e6b17dd67f9b4952988", [], [{:hpack, "~> 0.2.3", [hex: :hpack_erl, repo: "hexpm", optional: false]}, {:scribe, "~> 0.4", [hex: :scribe, repo: "hexpm", optional: false]}], "hexpm"},
+  "kadabra": {:hex, :kadabra, "0.2.2", "4e1d19ca6dd8df3171088f6ca9839039cab28c1fd9892e6b17dd67f9b4952988", [:mix], [{:hpack, "~> 0.2.3", [hex: :hpack_erl, repo: "hexpm", optional: false]}, {:scribe, "~> 0.4", [hex: :scribe, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [], [], "hexpm"},
   "pane": {:hex, :pane, "0.1.1", "4a9b46957a02991acbce012169ab7e8ecff74ad24886f94b142680062b10f167", [], [], "hexpm"},


### PR DESCRIPTION
FCM servers throw ENHANCE_YOUR_CALM for pings and close active connections after a
brief period of time. Pinging is not really necessary, though the config
option left in so as not to break API.