### PR TITLE
Change `Map.to_list/1` to `Enum.to_list/1` so that keyword lists can be used for configuration in addition to maps

### DIFF
--- a/lib/pigeon/adm/config.ex
+++ b/lib/pigeon/adm/config.ex
@@ -36,7 +36,7 @@ defmodule Pigeon.ADM.Config do
   end
   def new(name) when is_atom(name) do
     Application.get_env(:pigeon, :adm)[name]
-    |> Map.to_list
+    |> Enum.to_list()
     |> Keyword.put(:name, name)
     |> new()
   end

--- a/lib/pigeon/apns/config.ex
+++ b/lib/pigeon/apns/config.ex
@@ -120,7 +120,7 @@ defmodule Pigeon.APNS.Config do
   end
   def new(name) when is_atom(name) do
     Application.get_env(:pigeon, :apns)[name]
-    |> Map.to_list
+    |> Enum.to_list()
     |> Keyword.put(:name, name)
     |> new()
   end

--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -37,7 +37,7 @@ defmodule Pigeon.FCM.Config do
   end
   def new(name) when is_atom(name) do
     Application.get_env(:pigeon, :fcm)[name]
-    |> Map.to_list
+    |> Enum.to_list()
     |> Keyword.put(:name, name)
     |> new()
   end


### PR DESCRIPTION
The use case for this is that I am using the `conform` package for configuring releases. `conform` accepts configuration like this:

```
# The path to the APNS cert
pigeon.apns.apns_default.cert = "/path/to/dev_apns.crt"

# The path to the APNS key
pigeon.apns.apns_default.key = "/path/to/dev_apns.key"

# The mode that APNS should run in
# Allowed values: dev, prod
pigeon.apns.apns_default.mode = dev

# The FCM API key
pigeon.fcm.fcm_default.key = "<secret>"
```

And transforms it into the following form in the `sys.config` (keyword list):

```erlang
...
 {pigeon,
     [{apns,
          [{apns_default,
               [{cert,
                    <<"/Users/percy/Code/mindoula-server-elixir/tmp/dev_apns.crt">>},
                {key,
                    <<"/Users/percy/Code/mindoula-server-elixir/tmp/dev_apns.key">>},
                {mode,dev}]}]},
      {fcm,
          [{fcm_default,
               [{key,<<"AIzaSyCeqPf83-CjKOA5oGtsRLAhvyBQsN3-FdU">>}]}]}]},
...
```

By default, this results in a `:badmap` error:

```erlang
{"Kernel pid terminated",application_controller,"{application_start_failure,pigeon,{bad_return,{{'Elixir.Pigeon',start,[normal,[]]},{'EXIT',{{badmap,[{cert,<<\"/path/to/myapp/tmp/dev_apns.crt\">>},{key,<<\"/path/to/myapp/tmp/dev_apns.key\">>},{mode,dev}]},[{maps,to_list,[[{cert,<<\"/path/to/myapp/tmp/dev_apns.crt\">>},{key,<<\"/path/to/myapp/tmp/dev_apns.key\">>},{mode,dev}]],[]},{'Elixir.Pigeon.APNS.Config',new,1,[{file,\"lib/pigeon/apns/config.ex\"},{line,123}]},{'Elixir.Pigeon','-workers_for/3-fun-0-',3,[{file,\"lib/pigeon.ex\"},{line,68}]},{'Elixir.Enum','-map/2-lists^map/1-0-',2,[{file,\"lib/enum.ex\"},{line,1229}]},{'Elixir.Pigeon',workers,0,[{file,\"lib/pigeon.ex\"},{line,23}]},{'Elixir.Pigeon',start,2,[{file,\"lib/pigeon.ex\"},{line,18}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line,273}]}]}}}}}"}
```

By simply changing the `Map.to_list/1` references to `Enum.to_list/1`, we are able to support both maps and lists in the config.