### PR TITLE
V0.13

### DIFF
--- a/lib/pigeon/apns.ex
+++ b/lib/pigeon/apns.ex
@@ -74,11 +74,11 @@ defmodule Pigeon.APNS do
   @doc """
   Sends a push over APNS.
   """
-  @spec push([Notification.t], ((Notification.t) -> ()), Keyword.t) :: no_return
+
   def push(notification, on_response, opts) when is_list(notification) do
     for n <- notification, do: push(n, on_response, opts)
   end
-  @spec push(Notification.t, ((Notification.t) -> ()), Keyword.t) :: no_return
+
   def push(notification, on_response, opts) do
     worker_name = opts[:to] || Config.default_name
     GenServer.cast(worker_name, {:push, :apns, notification, on_response})

--- a/lib/pigeon/apns.ex
+++ b/lib/pigeon/apns.ex
@@ -74,11 +74,11 @@ defmodule Pigeon.APNS do
   @doc """
   Sends a push over APNS.
   """
-  @spec push([Notification.t], ((Notification.t) -> any()), Keyword.t) :: no_return
+  @spec push([Notification.t], ((Notification.t) -> no_return), Keyword.t) :: no_return
   def push(notification, on_response, opts) when is_list(notification) do
     for n <- notification, do: push(n, on_response, opts)
   end
-  @spec push(Notification.t, ((Notification.t) -> any()), Keyword.t) :: no_return
+  @spec push(Notification.t, ((Notification.t) -> no_return), Keyword.t) :: no_return
   def push(notification, on_response, opts) do
     worker_name = opts[:to] || Config.default_name
     GenServer.cast(worker_name, {:push, :apns, notification, on_response})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pigeon.Mixfile do
   def project do
     [app: :pigeon,
      name: "Pigeon",
-     version: "0.13.0",
+     version: "0.13.1",
      elixir: "~> 1.2",
      source_url: "https://github.com/codedge-llc/pigeon",
      description: description(),


### PR DESCRIPTION
We're using Pigeon 0.13. We would like to upgrade to v1, but we're hoping that we can first get our current version working with Elixir 1.6. Then we can upgrade to v1 of pigeon after that all works out.

Currently, Pigeon fails to compile with Elixir 1.6 because of a typespec bug. Here is a fix that makes it compile, but I'm not sure if it fits your "guide" on how you want typespecs done.

If this is acceptable, I'm hoping you'll do a quick version update on hex so that there is a 0.13.1 that works with Elixir 1.6.

Thanks for your time.