### PR TITLE
Clarification to keep key conversion from failing

### DIFF
--- a/docs/APNS Apple iOS.md
+++ b/docs/APNS Apple iOS.md
@@ -64,14 +64,13 @@ key and select _"Export..."_
      openssl pkcs12 -clcerts -nokeys -out cert.pem -in cert.p12
      ```
 
-6. Convert the key. Be sure to set a password here. You will need that
-password in order to remove it in the next step.
+6. Convert the key. Be sure to set a PEM pass phrase here. The pass phrase must be 4 or more characters in length or this will not work. You will need that pass phrase added here in order to remove it in the next step.
 
      ```
      openssl pkcs12 -nocerts -out key.pem -in key.p12
      ```
 
-7. Remove the password from the key.
+7. Remove the PEM pass phrase from the key.
 
      ```
      openssl rsa -in key.pem -out key_unencrypted.pem


### PR DESCRIPTION
If the PEM pass phrase is less than 4 characters it fails and there are no good error messages, google searches, or stack overflow posts to help you understand why it's failing. I added text to warn the reader of this.

I also changed the wording from "password" to "pass phrase" because that is the word used by the openssl script in the terminal. This help distinguish from the password that can, but not must be set when exporting the certificate or passkey.