### PR TITLE
fix: typo

### DIFF
--- a/lib/pigeon/fcm/notification.ex
+++ b/lib/pigeon/fcm/notification.ex
@@ -56,7 +56,7 @@ defmodule Pigeon.FCM.Notification do
           | {:update, {binary, binary}}
 
   @type regid_error_response ::
-          :device_essage_rate_exceeded
+          :device_message_rate_exceeded
           | :invalid_data_key
           | :invalid_package_name
           | :invalid_paramteres


### PR DESCRIPTION
I noticed this typo in the type spec and thought I'd make a PR for it. I was going to do it against `master` but I saw #109 and it had the same issue.