### PR TITLE
fix: apns-expiration header properly encoded

### DIFF
--- a/lib/pigeon/apns/notification.ex
+++ b/lib/pigeon/apns/notification.ex
@@ -3,7 +3,8 @@ defmodule Pigeon.APNS.Notification do
   Defines APNS notification struct and constructor functions.
   """
 
-  defstruct device_token: nil,
+  defstruct collapse_id: nil,
+            device_token: nil,
             expiration: nil,
             id: nil,
             payload: %{"aps" => %{}},
@@ -18,6 +19,7 @@ defmodule Pigeon.APNS.Notification do
   ## Examples
 
       %Pigeon.APNS.Notification{
+          collapse_id: nil,
           device_token: "device token",
           expiration: nil,
           id: nil, # Set on push response if nil
@@ -27,8 +29,9 @@ defmodule Pigeon.APNS.Notification do
       }
   """
   @type t :: %__MODULE__{
+          collapse_id: String.t() | nil,
           device_token: String.t() | nil,
-          expiration: String.t() | nil,
+          expiration: non_neg_integer | nil,
           id: String.t() | nil,
           payload: %{String.t() => String.t()},
           response: response,

--- a/test/apns_test.exs
+++ b/test/apns_test.exs
@@ -63,6 +63,8 @@ defmodule Pigeon.APNSTest do
           test_token(),
           test_topic()
         )
+        |> Map.put(:expiration, 0)
+        |> Map.put(:collapse_id, "test")
 
       assert Pigeon.APNS.push(n).response == :success
     end


### PR DESCRIPTION
Also: added support for apns-collapse-id header (with corresponding new
attribute on the Notification struct)