### PR TITLE
Added priority to notifications

### DIFF
--- a/lib/pigeon/apns/notification.ex
+++ b/lib/pigeon/apns/notification.ex
@@ -6,6 +6,7 @@ defmodule Pigeon.APNS.Notification do
   defstruct collapse_id: nil,
             device_token: nil,
             expiration: nil,
+            priority: nil,
             id: nil,
             payload: %{"aps" => %{}},
             topic: nil,
@@ -22,6 +23,7 @@ defmodule Pigeon.APNS.Notification do
           collapse_id: nil,
           device_token: "device token",
           expiration: nil,
+          priority: nil,
           id: nil, # Set on push response if nil
           payload: %{"aps" => %{"alert" => "push message"}},
           response: nil, # Set on push response
@@ -32,6 +34,7 @@ defmodule Pigeon.APNS.Notification do
           collapse_id: String.t() | nil,
           device_token: String.t() | nil,
           expiration: non_neg_integer | nil,
+          priority: non_neg_integer | nil,
           id: String.t() | nil,
           payload: %{String.t() => String.t()},
           response: response,
@@ -61,6 +64,7 @@ defmodule Pigeon.APNS.Notification do
       %Pigeon.APNS.Notification{
         device_token: "device token",
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"alert" => "push message"}},
         topic: nil
@@ -88,6 +92,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: "device token",
         expiration: nil,
+        priority: nil,
         id: "id_1234",
         payload: %{"aps" => %{"alert" => "push message"}},
         topic: "topic"
@@ -115,6 +120,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: nil,
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"alert" => "push message"}},
         topic: nil
@@ -136,6 +142,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: nil,
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"badge" => 5}},
         topic: nil
@@ -158,6 +165,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: nil,
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"sound" => "custom.aiff"}},
         topic: nil
@@ -180,6 +188,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: nil,
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"content-available" => 1}},
         topic: nil
@@ -199,6 +208,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: nil,
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"category" => "category"}},
         topic: nil
@@ -220,6 +230,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: nil,
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"mutable-content" => 1}},
         topic: nil
@@ -250,6 +261,7 @@ defmodule Pigeon.APNS.Notification do
         collapse_id: nil,
         device_token: "device token",
         expiration: nil,
+        priority: nil,
         id: nil,
         payload: %{"aps" => %{"alert" => "test message"}, "custom-key" => 1234},
         topic: nil

--- a/lib/pigeon/apns/shared.ex
+++ b/lib/pigeon/apns/shared.ex
@@ -11,6 +11,7 @@ defmodule Pigeon.APNS.Shared do
 
   @apns_id "apns-id"
   @apns_topic "apns-topic"
+  @apns_priority "apns-priority"
   @apns_expiration "apns-expiration"
   @apns_collapse_id "apns-collapse-id"
 
@@ -31,6 +32,7 @@ defmodule Pigeon.APNS.Shared do
     ]
     |> put_header(@apns_id, notification.id)
     |> put_header(@apns_topic, notification.topic)
+    |> put_header(@apns_priority, notification.priority)
     |> put_header(@apns_expiration, notification.expiration)
     |> put_header(@apns_collapse_id, notification.collapse_id)
   end

--- a/test/apns_test.exs
+++ b/test/apns_test.exs
@@ -25,6 +25,7 @@ defmodule Pigeon.APNSTest do
     )
     |> Map.put(:expiration, 0)
     |> Map.put(:collapse_id, "test")
+    |> Map.put(:priority, 10)
   end
 
   describe "start_connection/1" do


### PR DESCRIPTION
The `apns-priority` header field is currently unsupported.  Add `priority` as an element in the `Notification` struct, and include in the headers sent to the apns service.
