### PR TITLE
Add support for Confex configuration system

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,7 +2,7 @@ use Mix.Config
 
 config :pigeon, :fcm,
   fcm_default: %{
-    key: System.get_env("GCM_KEY")
+    key: {:system, :string, "GCM_KEY"}
   }
 
 config :pigeon, :apns,
@@ -14,6 +14,6 @@ config :pigeon, :apns,
 
 config :pigeon, :adm,
   adm_default: %{
-    client_id: System.get_env("ADM_OAUTH2_CLIENT_ID"),
-    client_secret: System.get_env("ADM_OAUTH2_CLIENT_SECRET")
+    client_id: {:system, :string, "ADM_OAUTH2_CLIENT_ID"},
+    client_secret: {:system, :string, "ADM_OAUTH2_CLIENT_SECRET"}
   }

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,12 +1,12 @@
 use Mix.Config
 
 config :pigeon, :test,
-  fcm_key: System.get_env("GCM_KEY"),
-  valid_fcm_reg_id: System.get_env("VALID_GCM_REG_ID"),
-  valid_apns_token: System.get_env("VALID_APNS_TOKEN"),
+  fcm_key: {:system, :string, "GCM_KEY"},
+  valid_fcm_reg_id: {:system, :string, "VALID_GCM_REG_ID"},
+  valid_apns_token: {:system, :string, "VALID_APNS_TOKEN"},
   apns_cert: "cert.pem",
   apns_key: "key_unencrypted.pem",
-  apns_topic: System.get_env("APNS_TOPIC")
+  apns_topic: {:system, :string, "APNS_TOPIC"}
 
 config :pigeon,
   debug_log: true,
@@ -19,7 +19,7 @@ config :pigeon,
 
 config :pigeon, :fcm,
   fcm_default: %{
-    key: System.get_env("GCM_KEY")
+    key: {:system, :string, "GCM_KEY"}
   }
 
 config :pigeon, :apns,
@@ -30,13 +30,13 @@ config :pigeon, :apns,
   },
   apns_jwt_static: %{
     key: "AuthKey.p8",
-    key_identifier: System.get_env("APNS_JWT_KEY_IDENTIFIER"),
-    team_id: System.get_env("APNS_JWT_TEAM_ID"),
+    key_identifier: {:system, :string, "APNS_JWT_KEY_IDENTIFIER"},
+    team_id: {:system, :string, "APNS_JWT_TEAM_ID"},
     mode: :dev
   }
 
 config :pigeon, :adm,
   adm_default: %{
-    client_id: System.get_env("ADM_OAUTH2_CLIENT_ID"),
-    client_secret: System.get_env("ADM_OAUTH2_CLIENT_SECRET")
+    client_id: {:system, :string, "ADM_OAUTH2_CLIENT_ID"},
+    client_secret: {:system, :string, "ADM_OAUTH2_CLIENT_SECRET"}
   }

--- a/lib/pigeon.ex
+++ b/lib/pigeon.ex
@@ -39,7 +39,7 @@ defmodule Pigeon do
   end
 
   defp env_workers do
-    case Application.get_env(:pigeon, :workers) do
+    case Confex.get_env(:pigeon, :workers) do
       nil ->
         []
 
@@ -91,5 +91,5 @@ defmodule Pigeon do
     Supervisor.start_child(:pigeon, spec)
   end
 
-  def debug_log?, do: Application.get_env(:pigeon, :debug_log, false)
+  def debug_log?, do: Confex.get_env(:pigeon, :debug_log, false)
 end

--- a/lib/pigeon/adm/config.ex
+++ b/lib/pigeon/adm/config.ex
@@ -36,7 +36,7 @@ defmodule Pigeon.ADM.Config do
   end
 
   def new(name) when is_atom(name) do
-    Application.get_env(:pigeon, :adm)[name]
+    Confex.get_env(:pigeon, :adm)[name]
     |> Enum.to_list()
     |> Keyword.put(:name, name)
     |> new()

--- a/lib/pigeon/apns/config_parser.ex
+++ b/lib/pigeon/apns/config_parser.ex
@@ -30,7 +30,7 @@ defmodule Pigeon.APNS.ConfigParser do
   end
 
   def parse(name) when is_atom(name) do
-    Application.get_env(:pigeon, :apns)[name]
+    Confex.get_env(:pigeon, :apns)[name]
     |> Enum.to_list()
     |> Keyword.put(:name, name)
     |> parse()

--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -37,7 +37,7 @@ defmodule Pigeon.FCM.Config do
   end
 
   def new(name) when is_atom(name) do
-    Application.get_env(:pigeon, :fcm)[name]
+    Confex.get_env(:pigeon, :fcm)[name]
     |> Enum.to_list()
     |> Keyword.put(:name, name)
     |> new()

--- a/lib/pigeon/http2/client.ex
+++ b/lib/pigeon/http2/client.ex
@@ -90,7 +90,7 @@ defmodule Pigeon.Http2.Client do
       Pigeon.Http2.Client.Kadabra
   """
   def default do
-    Application.get_env(:pigeon, :http2_client, Pigeon.Http2.Client.Kadabra)
+    Confex.get_env(:pigeon, :http2_client, Pigeon.Http2.Client.Kadabra)
   end
 
   @callback start() :: no_return

--- a/mix.exs
+++ b/mix.exs
@@ -44,7 +44,7 @@ defmodule Pigeon.Mixfile do
   defp elixirc_paths(_), do: ["lib"]
 
   def application do
-    [extra_applications: [:logger], mod: {Pigeon, []}]
+    [extra_applications: [:logger, :confex], mod: {Pigeon, []}]
   end
 
   defp deps do
@@ -53,6 +53,7 @@ defmodule Pigeon.Mixfile do
       {:httpoison, "~> 0.7 or ~> 1.0"},
       {:gen_stage, "~> 0.12"},
       {:joken, "~> 2.0.0"},
+      {:confex, "~> 3.4.0"},
       {:kadabra, "~> 0.4.3", optional: true},
       {:earmark, "~> 1.0", only: :dev},
       {:ex_doc, "~> 0.18", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -2,6 +2,7 @@
   "base64url": {:hex, :base64url, "0.0.1", "36a90125f5948e3afd7be97662a1504b934dd5dac78451ca6e9abf85a10286be", [:rebar], [], "hexpm"},
   "bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
   "certifi": {:hex, :certifi, "2.4.2", "75424ff0f3baaccfd34b1214184b6ef616d89e420b258bb0a5ea7d7bc628f7f0", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm"},
+  "confex": {:hex, :confex, "3.4.0", "8b1c3cc7a93320291abb31223a178df19d7f722ee816c05a8070c8c9a054560d", [:mix], [], "hexpm"},
   "credo": {:hex, :credo, "1.0.2", "88bc918f215168bf6ce7070610a6173c45c82f32baa08bdfc80bf58df2d103b6", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [:mix], [], "hexpm"},
   "dogma": {:hex, :dogma, "0.1.15", "5bceba9054b2b97a4adcb2ab4948ca9245e5258b883946e82d32f785340fd411", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, optional: false]}]},

--- a/test/apns/jwt_config_test.exs
+++ b/test/apns/jwt_config_test.exs
@@ -5,8 +5,8 @@ defmodule Pigeon.APNS.JWTConfigTest do
   def test_message(msg),
     do: "#{DateTime.to_string(DateTime.utc_now())} - #{msg}"
 
-  def test_topic, do: Application.get_env(:pigeon, :test)[:apns_topic]
-  def test_token, do: Application.get_env(:pigeon, :test)[:valid_apns_token]
+  def test_topic, do: Confex.get_env(:pigeon, :test)[:apns_topic]
+  def test_token, do: Confex.get_env(:pigeon, :test)[:valid_apns_token]
 
   test "sends a push with valid config" do
     n =

--- a/test/apns_test.exs
+++ b/test/apns_test.exs
@@ -7,8 +7,8 @@ defmodule Pigeon.APNSTest do
     "#{DateTime.to_string(DateTime.utc_now())} - #{msg}"
   end
 
-  def test_topic, do: Application.get_env(:pigeon, :test)[:apns_topic]
-  def test_token, do: Application.get_env(:pigeon, :test)[:valid_apns_token]
+  def test_topic, do: Confex.get_env(:pigeon, :test)[:apns_topic]
+  def test_token, do: Confex.get_env(:pigeon, :test)[:valid_apns_token]
 
   def bad_token do
     "00fc13adff785122b4ad28809a3420982341241421348097878e577c991de8f0"
@@ -31,11 +31,11 @@ defmodule Pigeon.APNSTest do
   describe "start_connection/1" do
     test "starts connection with opts keyword list" do
       opts = [
-        cert: Application.get_env(:pigeon, :test)[:apns_cert],
-        key: Application.get_env(:pigeon, :test)[:apns_key],
-        jwt_key: Application.get_env(:pigeon, :test)[:apns_jwt_key],
-        jwt_key_identifier: Application.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
-        jwt_team_id: Application.get_env(:pigeon, :test)[:apns_jwt_team_id],
+        cert: Confex.get_env(:pigeon, :test)[:apns_cert],
+        key: Confex.get_env(:pigeon, :test)[:apns_key],
+        jwt_key: Confex.get_env(:pigeon, :test)[:apns_jwt_key],
+        jwt_key_identifier: Confex.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
+        jwt_team_id: Confex.get_env(:pigeon, :test)[:apns_jwt_team_id],
         mode: :dev
       ]
 
@@ -52,11 +52,11 @@ defmodule Pigeon.APNSTest do
 
     test "configures ping_period if specified" do
       opts = [
-        cert: Application.get_env(:pigeon, :test)[:apns_cert],
-        key: Application.get_env(:pigeon, :test)[:apns_key],
-        jwt_key: Application.get_env(:pigeon, :test)[:apns_jwt_key],
-        jwt_key_identifier: Application.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
-        jwt_team_id: Application.get_env(:pigeon, :test)[:apns_jwt_team_id],
+        cert: Confex.get_env(:pigeon, :test)[:apns_cert],
+        key: Confex.get_env(:pigeon, :test)[:apns_key],
+        jwt_key: Confex.get_env(:pigeon, :test)[:apns_jwt_key],
+        jwt_key_identifier: Confex.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
+        jwt_team_id: Confex.get_env(:pigeon, :test)[:apns_jwt_team_id],
         mode: :dev,
         ping_period: 30_000
       ]
@@ -109,11 +109,11 @@ defmodule Pigeon.APNSTest do
       n = test_notification("push/1, custom_worker")
 
       opts = [
-        cert: Application.get_env(:pigeon, :test)[:apns_cert],
-        key: Application.get_env(:pigeon, :test)[:apns_key],
-        jwt_key: Application.get_env(:pigeon, :test)[:apns_jwt_key],
-        jwt_key_identifier: Application.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
-        jwt_team_id: Application.get_env(:pigeon, :test)[:apns_jwt_team_id],
+        cert: Confex.get_env(:pigeon, :test)[:apns_cert],
+        key: Confex.get_env(:pigeon, :test)[:apns_key],
+        jwt_key: Confex.get_env(:pigeon, :test)[:apns_jwt_key],
+        jwt_key_identifier: Confex.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
+        jwt_team_id: Confex.get_env(:pigeon, :test)[:apns_jwt_team_id],
         mode: :dev
       ]
 
@@ -126,11 +126,11 @@ defmodule Pigeon.APNSTest do
       n = test_notification("push/1, custom_worker")
 
       opts = [
-        cert: Application.get_env(:pigeon, :test)[:apns_cert],
-        key: Application.get_env(:pigeon, :test)[:apns_key],
-        jwt_key: Application.get_env(:pigeon, :test)[:apns_jwt_key],
-        jwt_key_identifier: Application.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
-        jwt_team_id: Application.get_env(:pigeon, :test)[:apns_jwt_team_id],
+        cert: Confex.get_env(:pigeon, :test)[:apns_cert],
+        key: Confex.get_env(:pigeon, :test)[:apns_key],
+        jwt_key: Confex.get_env(:pigeon, :test)[:apns_jwt_key],
+        jwt_key_identifier: Confex.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
+        jwt_team_id: Confex.get_env(:pigeon, :test)[:apns_jwt_team_id],
         mode: :dev,
         name: :custom
       ]
@@ -210,11 +210,11 @@ defmodule Pigeon.APNSTest do
       Pigeon.APNS.stop_connection(:default)
 
       opts = [
-        cert: Application.get_env(:pigeon, :test)[:apns_cert],
-        key: Application.get_env(:pigeon, :test)[:apns_key],
-        jwt_key: Application.get_env(:pigeon, :test)[:apns_jwt_key],
-        jwt_key_identifier: Application.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
-        jwt_team_id: Application.get_env(:pigeon, :test)[:apns_jwt_team_id],
+        cert: Confex.get_env(:pigeon, :test)[:apns_cert],
+        key: Confex.get_env(:pigeon, :test)[:apns_key],
+        jwt_key: Confex.get_env(:pigeon, :test)[:apns_jwt_key],
+        jwt_key_identifier: Confex.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
+        jwt_team_id: Confex.get_env(:pigeon, :test)[:apns_jwt_team_id],
         mode: :dev
       ]
 
@@ -234,11 +234,11 @@ defmodule Pigeon.APNSTest do
       n = test_notification("push/2 :ok, custom worker")
 
       opts = [
-        cert: Application.get_env(:pigeon, :test)[:apns_cert],
-        key: Application.get_env(:pigeon, :test)[:apns_key],
-        jwt_key: Application.get_env(:pigeon, :test)[:apns_jwt_key],
-        jwt_key_identifier: Application.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
-        jwt_team_id: Application.get_env(:pigeon, :test)[:apns_jwt_team_id],
+        cert: Confex.get_env(:pigeon, :test)[:apns_cert],
+        key: Confex.get_env(:pigeon, :test)[:apns_key],
+        jwt_key: Confex.get_env(:pigeon, :test)[:apns_jwt_key],
+        jwt_key_identifier: Confex.get_env(:pigeon, :test)[:apns_jwt_key_identifier],
+        jwt_team_id: Confex.get_env(:pigeon, :test)[:apns_jwt_team_id],
         mode: :dev,
         name: :custom
       ]

--- a/test/fcm/worker_test.exs
+++ b/test/fcm/worker_test.exs
@@ -4,7 +4,7 @@ defmodule Pigeon.FCM.WorkerTest do
   alias Pigeon.FCM
 
   defp valid_fcm_reg_id do
-    Application.get_env(:pigeon, :test)[:valid_fcm_reg_id]
+    Confex.get_env(:pigeon, :test)[:valid_fcm_reg_id]
   end
 
   defp get_consumer_pid(pid) do
@@ -33,7 +33,7 @@ defmodule Pigeon.FCM.WorkerTest do
 
   test "decrements connection count after disconnect" do
     opts = [
-      key: Application.get_env(:pigeon, :test)[:fcm_key]
+      key: Confex.get_env(:pigeon, :test)[:fcm_key]
     ]
 
     {:ok, pid} = FCM.start_connection(opts)
@@ -57,7 +57,7 @@ defmodule Pigeon.FCM.WorkerTest do
 
   test "decrements connection count after :down message" do
     opts = [
-      key: Application.get_env(:pigeon, :test)[:fcm_key]
+      key: Confex.get_env(:pigeon, :test)[:fcm_key]
     ]
 
     {:ok, pid} = FCM.start_connection(opts)

--- a/test/fcm_test.exs
+++ b/test/fcm_test.exs
@@ -9,12 +9,12 @@ defmodule Pigeon.FCMTest do
   @data %{"message" => "Test push"}
 
   defp valid_fcm_reg_id do
-    Application.get_env(:pigeon, :test)[:valid_fcm_reg_id]
+    Confex.get_env(:pigeon, :test)[:valid_fcm_reg_id]
   end
 
   describe "start_connection/1" do
     test "starts conneciton with opts keyword list" do
-      fcm_key = Application.get_env(:pigeon, :test)[:fcm_key]
+      fcm_key = Confex.get_env(:pigeon, :test)[:fcm_key]
 
       opts = [
         key: fcm_key
@@ -36,7 +36,7 @@ defmodule Pigeon.FCMTest do
         |> Notification.new(%{}, @data)
 
       opts = [
-        key: Application.get_env(:pigeon, :test)[:fcm_key]
+        key: Confex.get_env(:pigeon, :test)[:fcm_key]
       ]
 
       {:ok, worker_pid} = Pigeon.FCM.start_connection(opts)
@@ -52,7 +52,7 @@ defmodule Pigeon.FCMTest do
         |> Notification.new(%{}, @data)
 
       opts = [
-        key: Application.get_env(:pigeon, :test)[:fcm_key],
+        key: Confex.get_env(:pigeon, :test)[:fcm_key],
         name: :custom
       ]
 


### PR DESCRIPTION
This change alters the configuration to use Confex rather than calling `Application.get_env` directly. This allows config variables to be set in environment variables when building a release. (For releases the config script is evaluated at release build time rather than at startup, so you can't just call `System.get_env` in it to get the runtime environment variables).