### PR TITLE
Add apns-push-type header for iOS 13

### DIFF
--- a/lib/pigeon/apns/notification.ex
+++ b/lib/pigeon/apns/notification.ex
@@ -7,6 +7,7 @@ defmodule Pigeon.APNS.Notification do
             device_token: nil,
             expiration: nil,
             priority: nil,
+            push_type: "alert",
             id: nil,
             payload: %{"aps" => %{}},
             topic: nil,
@@ -24,6 +25,7 @@ defmodule Pigeon.APNS.Notification do
           device_token: "device token",
           expiration: nil,
           priority: nil,
+          push_type: "alert",
           id: nil, # Set on push response if nil
           payload: %{"aps" => %{"alert" => "push message"}},
           response: nil, # Set on push response
@@ -35,6 +37,7 @@ defmodule Pigeon.APNS.Notification do
           device_token: String.t() | nil,
           expiration: non_neg_integer | nil,
           priority: non_neg_integer | nil,
+          push_type: String.t() | nil,
           id: String.t() | nil,
           payload: %{String.t() => String.t()},
           response: response,
@@ -65,6 +68,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: "device token",
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"alert" => "push message"}},
         topic: nil
@@ -93,6 +97,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: "device token",
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: "id_1234",
         payload: %{"aps" => %{"alert" => "push message"}},
         topic: "topic"
@@ -121,6 +126,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: nil,
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"alert" => "push message"}},
         topic: nil
@@ -143,6 +149,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: nil,
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"badge" => 5}},
         topic: nil
@@ -166,6 +173,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: nil,
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"sound" => "custom.aiff"}},
         topic: nil
@@ -189,6 +197,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: nil,
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"content-available" => 1}},
         topic: nil
@@ -209,6 +218,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: nil,
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"category" => "category"}},
         topic: nil
@@ -231,6 +241,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: nil,
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"mutable-content" => 1}},
         topic: nil
@@ -262,6 +273,7 @@ defmodule Pigeon.APNS.Notification do
         device_token: "device token",
         expiration: nil,
         priority: nil,
+        push_type: "alert",
         id: nil,
         payload: %{"aps" => %{"alert" => "test message"}, "custom-key" => 1234},
         topic: nil

--- a/lib/pigeon/apns/shared.ex
+++ b/lib/pigeon/apns/shared.ex
@@ -12,6 +12,7 @@ defmodule Pigeon.APNS.Shared do
   @apns_id "apns-id"
   @apns_topic "apns-topic"
   @apns_priority "apns-priority"
+  @apns_push_type "apns-push-type"
   @apns_expiration "apns-expiration"
   @apns_collapse_id "apns-collapse-id"
 
@@ -33,6 +34,7 @@ defmodule Pigeon.APNS.Shared do
     |> put_header(@apns_id, notification.id)
     |> put_header(@apns_topic, notification.topic)
     |> put_header(@apns_priority, notification.priority)
+    |> put_header(@apns_push_type, notification.push_type)
     |> put_header(@apns_expiration, notification.expiration)
     |> put_header(@apns_collapse_id, notification.collapse_id)
   end


### PR DESCRIPTION
According to the [Apple documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns?language=objc) the new `apns-push-type` header is required for sending notifications to iOS 13 (and ignored by earlier versions).

This change adds a field to the `APNS.Notification` struct and sets the header when sending the notification.