### PR TITLE
support :PrivateKeyInfo for apns key pem_decode

### DIFF
--- a/lib/pigeon/apns/config.ex
+++ b/lib/pigeon/apns/config.ex
@@ -142,6 +142,7 @@ defmodule Pigeon.APNS.Config do
   defp key(bin) when is_binary(bin) do
     case :public_key.pem_decode(bin) do
       [{:RSAPrivateKey, key, _}] -> {:RSAPrivateKey, key}
+      [{:PrivateKeyInfo, key, _}] -> {:PrivateKeyInfo, key}
       _ -> {:error, {:invalid, bin}}
     end
   end


### PR DESCRIPTION
Attempting to use a string literal for configuring APNS and `:public_key.pem_decode` is returning `[{:PrivateKeyInfo, key, _}]` for the key I provided. This is for a cert/key that works fine when configuring `pigeon` using the filepath methods, which don't look to do this validation. Is this an OK change? Thanks for your awesome work!