### PR TITLE
Add case to handle single result

### DIFF
--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -173,6 +173,11 @@ defimpl Pigeon.Configurable, for: Pigeon.FCM.Config do
     ResultParser.parse(ids, results, on_response, notification)
   end
 
+  def parse_result(id, %{"message_id" => _} = result, on_response, notification)
+      when is_binary(id) do
+    parse_result([id], %{"results" => [result]}, on_response, notification)
+  end
+
   def parse_error(data) do
     case Poison.decode(data) do
       {:ok, response} ->


### PR DESCRIPTION
Our application calls `Pigeon.FCM.push/1` roughly like so:

```elixir
"/some/topic/name"
|> Pigeon.FCM.Notification.new(params, data)
|> Pigeon.FCM.Notification.put_content_available(true)
|> Pigeon.FCM.push()
```

but we get the following error:

```sh
[error] GenServer #PID<0.3526.0> terminating
** (FunctionClauseError) no function clause matching in Pigeon.Configurable.Pigeon.FCM.Config.parse_result/4
    (pigeon 1.5.0) lib/pigeon/fcm/config.ex:170: Pigeon.Configurable.Pigeon.FCM.Config.parse_result("/some/topic", %{"message_id" => <scrubbed-message-id>}, #Function<4.94564371/1 in Pigeon.FCM.sync_push/2>, %Pigeon.FCM.Notification{collapse_key: nil, condition: nil, content_available: false, dry_run: false, message_id: nil, mutable_content: false, payload: %{"data" => %{<scrubbed-data>, "notification" => %{<scrubbed-notif>}}, priority: :normal, registration_id: "/some/topic", response: [], restricted_package_name: nil, status: :success, time_to_live: 2419200})
    (pigeon 1.5.0) lib/pigeon/connection.ex:113: Pigeon.Connection.process_end_stream/2
    lib/gen_stage.ex:2086: GenStage.noreply_callback/3
    (stdlib 3.11.1) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib 3.11.1) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib 3.11.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```

It seems like the `parse_result` function needs to handle the case where it gets a single ID (that might be a topic) and a single result that isn't wrapped in `%{"results" => _}`.

A relevant issue found when trying to debug: https://github.com/codedge-llc/pigeon/issues/156