### PR TITLE
fix(fcm): ensure unregistered tokens correctly return `:unregistered`

### DIFF
--- a/lib/pigeon/fcm/error.ex
+++ b/lib/pigeon/fcm/error.ex
@@ -11,9 +11,12 @@ defmodule Pigeon.FCM.Error do
     |> parse_response()
   end
 
+  # An unregistered token will always be sent as a `NOT_FOUND` error with a 404
+  @unregistered_statuses ["NOT_FOUND", "UNREGISTERED"]
+
   defp parse_response("UNSPECIFIED_ERROR"), do: :unspecified_error
   defp parse_response("INVALID_ARGUMENT"), do: :invalid_argument
-  defp parse_response("UNREGISTERED"), do: :unregistered
+  defp parse_response(status) when status in @unregistered_statuses, do: :unregistered
   defp parse_response("SENDER_ID_MISMATCH"), do: :sender_id_mismatch
   defp parse_response("QUOTA_EXCEEDED"), do: :quota_exceeded
   defp parse_response("UNAVAILABLE"), do: :unavailable


### PR DESCRIPTION
Currently an unregistered token in FCM will return an `unknown_error` response, which is incorrect. This PR correctly returns an `unregistered` atom for this case.

The error coming back from FCM is:

```
{
  code: 404, 
  details: [
    {
      @type: type.googleapis.com/google.firebase.fcm.v1.FcmError, 
      errorCode: UNREGISTERED
    }
  ], 
  message: Requested entity was not found., 
  status: NOT_FOUND
}
```