### PR TITLE
ci: add prettier and check jobs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,13 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
 ---
 
 ### Environment
 
-* Elixir & Erlang/OTP versions (`elixir --version`): 
-* Operating system: 
+- Elixir & Erlang/OTP versions (`elixir --version`):
+- Operating system:
+- Pigeon version:
 
 ### Current behavior
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,6 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,6 @@ on:
   pull_request:
     branches: [master]
 
-.elixir_base: &elixir_base
-  - uses: actions/checkout@v2
-  - name: Set up Elixir
-    uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-    with:
-      elixir-version: "1.13.4"
-      otp-version: "24.1"
-  - name: Restore dependencies cache
-    uses: actions/cache@v2
-    with:
-      path: deps
-      key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-      restore-keys: ${{ runner.os }}-mix-
-  - name: Install dependencies
-    run: mix deps.get
-
 jobs:
   prettier:
     name: Prettier
@@ -39,7 +23,20 @@ jobs:
     name: Format/Credo
     runs-on: ubuntu-latest
     steps:
-      - <<:*elixir_base
+      - uses: actions/checkout@v2
+      - name: Set up Elixir
+        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+        with:
+          elixir-version: "1.13.4"
+          otp-version: "24.1"
+      - name: Restore dependencies cache
+        uses: actions/cache@v2
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+      - name: Install dependencies
+        run: mix deps.get
       - name: Run formatter
         run: mix format --check-formatted
       - name: Run Credo
@@ -48,7 +45,20 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - <<:*elixir_base
+      - uses: actions/checkout@v2
+      - name: Set up Elixir
+        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+        with:
+          elixir-version: "1.13.4"
+          otp-version: "24.1"
+      - name: Restore dependencies cache
+        uses: actions/cache@v2
+        with:
+          path: deps
+          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+          restore-keys: ${{ runner.os }}-mix-
+      - name: Install dependencies
+        run: mix deps.get
       - name: Run tests
         env:
           ADM_OAUTH2_CLIENT_ID: ${{ secrets.ADM_OAUTH2_CLIENT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,22 @@ on:
   pull_request:
     branches: [master]
 
+.elixir_base: &elixir_base
+  - uses: actions/checkout@v2
+  - name: Set up Elixir
+    uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
+    with:
+      elixir-version: "1.13.4"
+      otp-version: "24.1"
+  - name: Restore dependencies cache
+    uses: actions/cache@v2
+    with:
+      path: deps
+      key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
+      restore-keys: ${{ runner.os }}-mix-
+  - name: Install dependencies
+    run: mix deps.get
+
 jobs:
   prettier:
     name: Prettier
@@ -19,24 +35,20 @@ jobs:
         uses: creyD/prettier_action@v4.2
         with:
           prettier_options: --check --no-error-on-unmatched-pattern **/*.{json,md,yml,yaml}
-  build:
+  check:
+    name: Format/Credo
+    runs-on: ubuntu-latest
+    steps:
+      - <<:*elixir_base
+      - name: Run formatter
+        run: mix format --check-formatted
+      - name: Run Credo
+        run: mix credo
+  test:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Elixir
-        uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
-        with:
-          elixir-version: "1.13.4"
-          otp-version: "24.1"
-      - name: Restore dependencies cache
-        uses: actions/cache@v2
-        with:
-          path: deps
-          key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}
-          restore-keys: ${{ runner.os }}-mix-
-      - name: Install dependencies
-        run: mix deps.get
+      - <<:*elixir_base
       - name: Run tests
         env:
           ADM_OAUTH2_CLIENT_ID: ${{ secrets.ADM_OAUTH2_CLIENT_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,28 @@ on:
     branches: [master]
 
 jobs:
-  build:
-    name: Build and test
+  prettier:
+    name: Prettier
     runs-on: ubuntu-latest
-
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
+      - name: Run Prettier
+        uses: creyD/prettier_action@v4.2
+        with:
+          prettier_options: --check --no-error-on-unmatched-pattern **/*.{json,md,yml,yaml}
+  build:
+    name: Test
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Set up Elixir
         uses: erlef/setup-beam@988e02bfe678367a02564f65ca2e37726dc0268f
         with:
-          elixir-version: "1.13.4" # Define the elixir version [required]
-          otp-version: "24.1" # Define the OTP version [required]
+          elixir-version: "1.13.4"
+          otp-version: "24.1"
       - name: Restore dependencies cache
         uses: actions/cache@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ scratchpad.txt
 *.swp
 .idea
 pigeon.iml
+.envrc

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+_build
+cover
+deps
+dist
+doc

--- a/README.md
+++ b/README.md
@@ -41,18 +41,21 @@ See [Pigeon.Dispatcher](https://hexdocs.pm/pigeon/2.0.0-rc.0/Pigeon.Dispatcher.h
 
 Want to write a Pigeon adapter for an unsupported push notification service?
 
-See [Pigeon.Adapter](https://hexdocs.pm/pigeon/2.0.0-rc.0/Pigeon.Adapter.html) for instructions.
+See [Pigeon.Adapter](https://hexdocs.pm/pigeon/2.0.0-rc.1/Pigeon.Adapter.html) for instructions.
 
 ## Contributing
 
 ### Testing
 
-Unit tests can be run with `mix test` or `mix coveralls.html`.
+Unit tests can be run with `mix test` or `mix coveralls.html`. Environment variables will need to be set for
+various credentials. See [config/test.exs](https://github.com/codedge-llc/pigeon/blob/master/config/test.exs)
+for the full list.
 
 ### Formatting
 
-This project uses Elixir's `mix format` for formatting. Add a hook in your editor of choice to
-run it after a save. Be sure it respects this project's `.formatter.exs`.
+This project uses Elixir's `mix format` and [Prettier](https://prettier.io) for formatting.
+Add hooks in your editor of choice to run it after a save. Be sure it respects this project's
+`.formatter.exs`.
 
 ### Commits
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,12 +1,12 @@
 import Config
 
 config :pigeon, :test,
-  fcm_key: System.get_env("GCM_KEY"),
-  valid_fcm_reg_id: System.get_env("VALID_GCM_REG_ID"),
-  valid_apns_token: System.get_env("VALID_APNS_TOKEN"),
   apns_cert: System.get_env("APNS_CERT"),
   apns_key: System.get_env("APNS_KEY_UNENCRYPTED"),
-  apns_topic: System.get_env("APNS_TOPIC")
+  apns_topic: System.get_env("APNS_TOPIC"),
+  fcm_key: System.get_env("GCM_KEY"),
+  valid_apns_token: System.get_env("VALID_APNS_TOKEN"),
+  valid_fcm_reg_id: System.get_env("VALID_GCM_REG_ID")
 
 config :pigeon, PigeonTest.ADM,
   adapter: Pigeon.ADM,

--- a/docs/ADM Amazon Android.md
+++ b/docs/ADM Amazon Android.md
@@ -2,9 +2,6 @@
 
 ## Usage
 
-
-
-
 1. Set your environment variables.
 
    ```elixir

--- a/docs/ADM Amazon Android.md
+++ b/docs/ADM Amazon Android.md
@@ -2,77 +2,80 @@
 
 ## Usage
 
+
+
+
 1. Set your environment variables.
 
-    ```elixir
-    config :pigeon, :adm,
-      client_id: "your_oauth2_client_id_here",
-      client_secret: "your_oauth2_client_secret_here"
-    ```
+   ```elixir
+   config :pigeon, :adm,
+     client_id: "your_oauth2_client_id_here",
+     client_secret: "your_oauth2_client_secret_here"
+   ```
 
 2. Create a notification packet.
 
-    ```elixir
-    msg = %{ "body" => "your message" }
-    n = Pigeon.ADM.Notification.new("your device registration ID", msg)
-    ```
+   ```elixir
+   msg = %{ "body" => "your message" }
+   n = Pigeon.ADM.Notification.new("your device registration ID", msg)
+   ```
 
 3. Send the packet.
 
-    ```elixir
-    Pigeon.ADM.push(n)
-    ```
+   ```elixir
+   Pigeon.ADM.push(n)
+   ```
 
 ## Handling Push Responses
 
 1. Pass an optional anonymous function as your second parameter.
 
-    ```elixir
-    data = %{ message: "your message" }
-    n = Pigeon.ADM.Notification.new("device registration ID", data)
-    Pigeon.ADM.push(n, on_response: fn(x) -> IO.inspect(x) end)
-    ```
+   ```elixir
+   data = %{ message: "your message" }
+   n = Pigeon.ADM.Notification.new("device registration ID", data)
+   Pigeon.ADM.push(n, on_response: fn(x) -> IO.inspect(x) end)
+   ```
 
 2. Responses return a notification with an updated `:response` key.
    You could handle responses like so:
 
-    ```elixir
-    on_response_handler = fn(x) ->
-      case x.response do
-        :success ->
-          # Push successful
-          :ok
-        :update ->
-          new_reg_id = x.updated_registration_id
-          # Update the registration ID in the database
-        :invalid_registration_id ->
-          # Remove the bad ID from the database
-        :unregistered ->
-          # Remove the bad ID from the database
-        error ->
-          # Handle other errors
-      end
-    end
+   ```elixir
+   on_response_handler = fn(x) ->
+     case x.response do
+       :success ->
+         # Push successful
+         :ok
+       :update ->
+         new_reg_id = x.updated_registration_id
+         # Update the registration ID in the database
+       :invalid_registration_id ->
+         # Remove the bad ID from the database
+       :unregistered ->
+         # Remove the bad ID from the database
+       error ->
+         # Handle other errors
+     end
+   end
 
-    data = %{ message: "your message" }
-    n = Pigeon.ADM.Notification.new("your registration id", data)
-    Pigeon.ADM.push(n, on_response: on_response_handler)
-    ```
+   data = %{ message: "your message" }
+   n = Pigeon.ADM.Notification.new("your registration id", data)
+   Pigeon.ADM.push(n, on_response: on_response_handler)
+   ```
 
 ## Error Responses
 
-*Taken from [Amazon Device Messaging docs](https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/06-sending-a-message)*
+_Taken from [Amazon Device Messaging docs](https://developer.amazon.com/public/apis/engage/device-messaging/tech-docs/06-sending-a-message)_
 
-|Reason                           |Description                      |
-|---------------------------------|---------------------------------|
-|`:invalid_registration_id`       |Invalid Registration Token       |
-|`:invalid_data`                  |Bad format JSON data             |
-|`:invalid_consolidation_key`     |Invalid Consolidation Key        |
-|`:invalid_expiration`            |Invalid expiresAfter value       |
-|`:invalid_checksum`              |Invalid md5 value                |
-|`:invalid_type`                  |Invalid Type header              |
-|`:unregistered`                  |App instance no longer available |
-|`:access_token_expired`          |Expired OAuth access token       |
-|`:message_too_large`             |Data size exceeds 6 KB           |
-|`:max_rate_exceeded`             |See Retry-After response header  |
-|`:unknown_error`                 |Unknown Error                    |
+| Reason                       | Description                      |
+| ---------------------------- | -------------------------------- |
+| `:invalid_registration_id`   | Invalid Registration Token       |
+| `:invalid_data`              | Bad format JSON data             |
+| `:invalid_consolidation_key` | Invalid Consolidation Key        |
+| `:invalid_expiration`        | Invalid expiresAfter value       |
+| `:invalid_checksum`          | Invalid md5 value                |
+| `:invalid_type`              | Invalid Type header              |
+| `:unregistered`              | App instance no longer available |
+| `:access_token_expired`      | Expired OAuth access token       |
+| `:message_too_large`         | Data size exceeds 6 KB           |
+| `:max_rate_exceeded`         | See Retry-After response header  |
+| `:unknown_error`             | Unknown Error                    |

--- a/docs/APNS Apple iOS.md
+++ b/docs/APNS Apple iOS.md
@@ -4,184 +4,185 @@
 
 1. Set your environment variables. See below for setting up your certificate and key.
 
-    ```elixir
-    config :pigeon, :apns,
-      apns_default: %{
-        cert: "cert.pem",
-        key: "key_unencrypted.pem",
-        mode: :dev
-      }
-    ```
+   ```elixir
+   config :pigeon, :apns,
+     apns_default: %{
+       cert: "cert.pem",
+       key: "key_unencrypted.pem",
+       mode: :dev
+     }
+   ```
 
-    This config sets up a `default` socket connection to send to APNS servers. `cert` and `key` can be any of the following:
-    * Static file path
-    * Full-text string of the file contents (useful for environment variables)
-    * `{:my_app, "certs/cert.pem"}` (indicates path relative to the `priv` folder of the given application)
+   This config sets up a `default` socket connection to send to APNS servers. `cert` and `key` can be any of the following:
 
-    Alternatively, you can use token based authentication:
+   - Static file path
+   - Full-text string of the file contents (useful for environment variables)
+   - `{:my_app, "certs/cert.pem"}` (indicates path relative to the `priv` folder of the given application)
 
-    ```elixir
-    config :pigeon, :apns,
-      apns_default: %{
-        key: "AuthKey.p8",
-        key_identifier: "ABC1234567",
-        team_id: "DEF8901234",
-        mode: :dev
-      }
-    ```
+   Alternatively, you can use token based authentication:
 
-    * `:key` - Created and downloaded via your developer account. Like `:cert` this can be a file path, file contents string or tuple
-    * `:key_identifier` - The 10-character key identifier associated with `:key`, obtained from your developer account
-    * `:team_id` - Your 10-character Team ID, obtained from your developer account
+   ```elixir
+   config :pigeon, :apns,
+     apns_default: %{
+       key: "AuthKey.p8",
+       key_identifier: "ABC1234567",
+       team_id: "DEF8901234",
+       mode: :dev
+     }
+   ```
+
+   - `:key` - Created and downloaded via your developer account. Like `:cert` this can be a file path, file contents string or tuple
+   - `:key_identifier` - The 10-character key identifier associated with `:key`, obtained from your developer account
+   - `:team_id` - Your 10-character Team ID, obtained from your developer account
 
 2. Create a notification packet. **Note: Your push topic is generally the app's bundle identifier.**
 
-    ```elixir
-    n = Pigeon.APNS.Notification.new("your message", "your device token", "your push topic (optional)")
-    ```
+   ```elixir
+   n = Pigeon.APNS.Notification.new("your message", "your device token", "your push topic (optional)")
+   ```
 
 3. Send the packet. Pushes are synchronous and return the notification with an
    updated `:response` key.
 
-    ```elixir
-    Pigeon.APNS.push(n)
-    ```
+   ```elixir
+   Pigeon.APNS.push(n)
+   ```
 
 ## Notification Struct
 
 The contents of `payload` is what will be received on the iOS device. If
 updating this field directly, use strings for your keys. It is recommended
-to use the convenience functions defined in *Notifications with Custom Data*.
+to use the convenience functions defined in _Notifications with Custom Data_.
 `expiration` is a UNIX epoch date in seconds (UTC). Passing a value of
 `0` expires the notification immediately and Apple will not attempt to
 redeliver it.
 
-  ```elixir
-  %Pigeon.APNS.Notification{
-    collapse_id: String.t() | nil,
-    device_token: String.t() | nil,
-    expiration: non_neg_integer | nil,
-    id: String.t() | nil,
-    payload: %{String.t() => String.t()},
-    response: atom,
-    topic: String.t() | nil
-  }
-  ```
+```elixir
+%Pigeon.APNS.Notification{
+  collapse_id: String.t() | nil,
+  device_token: String.t() | nil,
+  expiration: non_neg_integer | nil,
+  id: String.t() | nil,
+  payload: %{String.t() => String.t()},
+  response: atom,
+  topic: String.t() | nil
+}
+```
 
 ## Generating Your Certificate and Key .pem
 
 1. In Keychain Access, right-click your push certificate and
-select _"Export..."_
+   select _"Export..."_
 2. Export the certificate as `cert.p12`
 3. Click the dropdown arrow next to the certificate, right-click the private
-key and select _"Export..."_
+   key and select _"Export..."_
 4. Export the private key as `key.p12`
 5. From a shell, convert the certificate.
 
-     ```
-     openssl pkcs12 -clcerts -nokeys -out cert.pem -in cert.p12
-     ```
+   ```
+   openssl pkcs12 -clcerts -nokeys -out cert.pem -in cert.p12
+   ```
 
 6. Convert the key. Be sure to set a PEM pass phrase here. The pass phrase must be 4 or more characters in length or this will not work. You will need that pass phrase added here in order to remove it in the next step.
 
-     ```
-     openssl pkcs12 -nocerts -out key.pem -in key.p12
-     ```
+   ```
+   openssl pkcs12 -nocerts -out key.pem -in key.p12
+   ```
 
 7. Remove the PEM pass phrase from the key.
 
-     ```
-     openssl rsa -in key.pem -out key_unencrypted.pem
-     ```
+   ```
+   openssl rsa -in key.pem -out key_unencrypted.pem
+   ```
 
 8. `cert.pem` and `key_unencrypted.pem` can now be used as the cert and key
-in `Pigeon.push`, respectively. Set them in your `config.exs`
+   in `Pigeon.push`, respectively. Set them in your `config.exs`
 
 ## Notifications with Custom Data
 
 Notifications can contain additional information in `payload`. (e.g. setting
 badge counters or defining custom sounds)
 
-  ```elixir
-  import Pigeon.APNS.Notification
-  n = Pigeon.APNS.Notification.new("message", "device token", "push topic")
-  |> put_badge(5)
-  |> put_sound("default")
-  |> put_content_available
-  |> put_mutable_content
-  |> put_category("category")
-  |> put_interruption_level("time-sensitive")
-  ```
-  
+```elixir
+import Pigeon.APNS.Notification
+n = Pigeon.APNS.Notification.new("message", "device token", "push topic")
+|> put_badge(5)
+|> put_sound("default")
+|> put_content_available
+|> put_mutable_content
+|> put_category("category")
+|> put_interruption_level("time-sensitive")
+```
+
 Using a more complex `alert` dictionary?
 
-  ```elixir
-  n
-  |> put_alert(%{
-    "title" => "alert title",
-    "body" => "alert body"
-  })
-  ```
-  
+```elixir
+n
+|> put_alert(%{
+  "title" => "alert title",
+  "body" => "alert body"
+})
+```
+
 Define custom payload data like so:
 
-  ```elixir
-  n
-  |> put_custom(%{"your-custom-key" => %{
-      "custom-value" => 500
-    }})
-  ```
+```elixir
+n
+|> put_custom(%{"your-custom-key" => %{
+    "custom-value" => 500
+  }})
+```
 
 ## Custom Worker Connections
 
 Multiple APNS worker connections can be configured simultaneously.
 Useful for supporting multiple apps and/or certificates at once.
 
-  ```elixir
-  config :pigeon, :apns,
-    default: %{
-      cert: "cert.pem",
-      key: "key_unencrypted.pem",
-      mode: :dev
-    },
-    custom_worker: %{
-      cert: "another_cert.pem",
-      key: "another_key_unencrypted.pem",
-      mode: :prod
-    }
-  ```
+```elixir
+config :pigeon, :apns,
+  default: %{
+    cert: "cert.pem",
+    key: "key_unencrypted.pem",
+    mode: :dev
+  },
+  custom_worker: %{
+    cert: "another_cert.pem",
+    key: "another_key_unencrypted.pem",
+    mode: :prod
+  }
+```
 
 Send pushes with a `to` option in your second parameter.
 
-  ```elixir
-  n = Pigeon.APNS.Notification.new("message", "device token", "push topic")
-  Pigeon.APNS.push(n, to: :custom_worker)
-  ```
+```elixir
+n = Pigeon.APNS.Notification.new("message", "device token", "push topic")
+Pigeon.APNS.push(n, to: :custom_worker)
+```
 
 You can also start connections manually.
 
-  ```elixir
-  iex> {:ok, pid} = Pigeon.APNS.start_connection(cert: "cert.pem",
-  ...> key: "key.pem", mode: :dev)
-  iex> Pigeon.APNS.push(notif, to: pid)
+```elixir
+iex> {:ok, pid} = Pigeon.APNS.start_connection(cert: "cert.pem",
+...> key: "key.pem", mode: :dev)
+iex> Pigeon.APNS.push(notif, to: pid)
 
-  iex> Pigeon.APNS.start_connection(cert: "cert.pem", key: "key.pem",
-  ...> mode: :dev, name: :custom)
-  iex> Pigeon.APNS.push(notif, to: :custom)
-  ```
+iex> Pigeon.APNS.start_connection(cert: "cert.pem", key: "key.pem",
+...> mode: :dev, name: :custom)
+iex> Pigeon.APNS.push(notif, to: :custom)
+```
 
 ## Asynchronous Pushing
 
-1. Pass an `on_response` option with an anonymous function in your
-second parameter.
+1.  Pass an `on_response` option with an anonymous function in your
+    second parameter.
 
-    ```elixir
-    n = Pigeon.APNS.Notification.new("message", "device token", "push topic")
-    Pigeon.APNS.push(n, on_response: fn(x) -> IO.inspect(x) end)
-    ```
+        ```elixir
+        n = Pigeon.APNS.Notification.new("message", "device token", "push topic")
+        Pigeon.APNS.push(n, on_response: fn(x) -> IO.inspect(x) end)
+        ```
 
-2. Responses return a notification with an updated `:response` key. 
-   You could handle responses like so:
+2.  Responses return a notification with an updated `:response` key.
+    You could handle responses like so:
 
     ```elixir
     handler = fn(%Pigeon.APNS.Notification{response: response}) ->
@@ -201,7 +202,7 @@ second parameter.
 
 ## Error Responses
 
-*Taken from [APNS Provider API](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW17)*
+_Taken from [APNS Provider API](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/CommunicatingwithAPNs.html#//apple_ref/doc/uid/TP40008194-CH11-SW17)_
 
 | Reason                             | Description                                                                                                                                                                                 |
 | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/FCM Android.md
+++ b/docs/FCM Android.md
@@ -4,122 +4,122 @@
 
 1. Set your environment variables.
 
-    ```elixir
-    config :pigeon, :fcm,
-      fcm_default: %{
-        key: "your_fcm_key_here"
-      }
-    ```
+   ```elixir
+   config :pigeon, :fcm,
+     fcm_default: %{
+       key: "your_fcm_key_here"
+     }
+   ```
 
-2. Create a notification packet. 
+2. Create a notification packet.
 
-    ```elixir
-    msg = %{"body" => "your message"}
-    n = Pigeon.FCM.Notification.new("your device registration ID", msg)
-    ```
- 
+   ```elixir
+   msg = %{"body" => "your message"}
+   n = Pigeon.FCM.Notification.new("your device registration ID", msg)
+   ```
+
 3. Send the packet. Pushes are synchronous and return the notification with
    updated `:status` and `:response` keys. If `:status` is success, `:response`
    will contain a keyword list of individual registration ID responses.
 
-    ```elixir
-    Pigeon.FCM.push(n)
-    ```
+   ```elixir
+   Pigeon.FCM.push(n)
+   ```
 
 ## Sending to Multiple Registration IDs
 
 Pass in a list of registration IDs, as many as you want.
 
-  ```elixir
-  msg = %{"body" => "your message"}
-  n = Pigeon.FCM.Notification.new(["first ID", "second ID"], msg)
-  ```
+```elixir
+msg = %{"body" => "your message"}
+n = Pigeon.FCM.Notification.new(["first ID", "second ID"], msg)
+```
 
 ## Notification Struct
 
-  ```elixir
-  %Pigeon.FCM.Notification{
-    collapse_key: nil | String.t(),
-    dry_run: boolean,
-    message_id: nil | String.t(),
-    payload: %{...},
-    priority: :normal | :high,
-    registration_id: String.t() | [String.t(), ...],
-    response: [] | [{atom, String.t()}, ...], | atom,
-    restricted_package_name: nil | String.t(),
-    status: atom | nil,
-    time_to_live: non_neg_integer
-  }
-  ```
+```elixir
+%Pigeon.FCM.Notification{
+  collapse_key: nil | String.t(),
+  dry_run: boolean,
+  message_id: nil | String.t(),
+  payload: %{...},
+  priority: :normal | :high,
+  registration_id: String.t() | [String.t(), ...],
+  response: [] | [{atom, String.t()}, ...], | atom,
+  restricted_package_name: nil | String.t(),
+  status: atom | nil,
+  time_to_live: non_neg_integer
+}
+```
 
 ## Notifications with Custom Data
 
 FCM accepts both `notification` and `data` keys in its JSON payload. Set them like so:
 
-  ```elixir
-  notification = %{"body" => "your message"}
-  data = %{"key" => "value"}
-  Pigeon.FCM.Notification.new("registration ID", notification, data)
-  ```
+```elixir
+notification = %{"body" => "your message"}
+data = %{"key" => "value"}
+Pigeon.FCM.Notification.new("registration ID", notification, data)
+```
 
 or
 
-  ```elixir
-  Pigeon.FCM.Notification.new("registration ID")
-  |> put_notification(%{"body" => "your message"})
-  |> put_data(%{"key" => "value"})
-  ```
- 
+```elixir
+Pigeon.FCM.Notification.new("registration ID")
+|> put_notification(%{"body" => "your message"})
+|> put_data(%{"key" => "value"})
+```
+
 ## Handling Push Responses
 
 1. Pass an optional anonymous function as your second parameter.
 
-    ```elixir
-    data = %{message: "your message"}
-    n = Pigeon.FCM.Notification.new(data, "device registration ID")
-    Pigeon.FCM.push(n, fn(x) -> IO.inspect(x) end)
-    {:ok, %Pigeon.FCM.Notification{...}}
-    ```
+   ```elixir
+   data = %{message: "your message"}
+   n = Pigeon.FCM.Notification.new(data, "device registration ID")
+   Pigeon.FCM.push(n, fn(x) -> IO.inspect(x) end)
+   {:ok, %Pigeon.FCM.Notification{...}}
+   ```
 
 2. Responses return the notification with an updated response.
 
-    ```elixir
-    on_response = fn(n) ->
-      case n.status do
-        :success ->
-          bad_regids = FCM.Notification.remove?(n)
-          to_retry = FCM.Notification.retry?(n)
-          # Handle updated regids, remove bad ones, etc
-        :unauthorized ->
-          # Bad FCM key
-        error ->
-          # Some other error
-      end
-    end
-    
-    data = %{message: "your message"}
-    n = Pigeon.FCM.Notification.new("your device token", data)
-    Pigeon.FCM.push(n, on_response: on_response)
-    ```
+   ```elixir
+   on_response = fn(n) ->
+     case n.status do
+       :success ->
+         bad_regids = FCM.Notification.remove?(n)
+         to_retry = FCM.Notification.retry?(n)
+         # Handle updated regids, remove bad ones, etc
+       :unauthorized ->
+         # Bad FCM key
+       error ->
+         # Some other error
+     end
+   end
+
+   data = %{message: "your message"}
+   n = Pigeon.FCM.Notification.new("your device token", data)
+   Pigeon.FCM.push(n, on_response: on_response)
+   ```
 
 ## Error Responses
 
-*Slightly modified from [FCM Server Reference](https://firebase.google.com/docs/cloud-messaging/http-server-ref#error-codes)*
+_Slightly modified from [FCM Server Reference](https://firebase.google.com/docs/cloud-messaging/http-server-ref#error-codes)_
 
-|Reason                           |Description                  |
-|---------------------------------|-----------------------------|
-|`:missing_registration`          |Missing Registration Token   |
-|`:invalid_registration`          |Invalid Registration Token   |
-|`:not_registered`                |Unregistered Device          |
-|`:invalid_package_name`          |Invalid Package Name         |
-|`:authentication_error`          |Authentication Error         |
-|`:mismatch_sender_id`            |Mismatched Sender            |
-|`:invalid_json`                  |Invalid JSON                 |
-|`:message_too_big`               |Message Too Big              |
-|`:invalid_data_key`              |Invalid Data Key             |
-|`:invalid_ttl`                   |Invalid Time to Live         |
-|`:unavailable`                   |Timeout                      |
-|`:internal_server_error`         |Internal Server Error        |
-|`:device_message_rate_exceeded`  |Message Rate Exceeded        |
-|`:topics_message_rate_exceeded`  |Topics Message Rate Exceeded |
-|`:unknown_error`                 |Unknown Error                |
+| Reason                          | Description                  |
+| ------------------------------- | ---------------------------- |
+| `:missing_registration`         | Missing Registration Token   |
+| `:invalid_registration`         | Invalid Registration Token   |
+| `:not_registered`               | Unregistered Device          |
+| `:invalid_package_name`         | Invalid Package Name         |
+| `:authentication_error`         | Authentication Error         |
+| `:mismatch_sender_id`           | Mismatched Sender            |
+| `:invalid_json`                 | Invalid JSON                 |
+| `:message_too_big`              | Message Too Big              |
+| `:invalid_data_key`             | Invalid Data Key             |
+| `:invalid_ttl`                  | Invalid Time to Live         |
+| `:unavailable`                  | Timeout                      |
+| `:internal_server_error`        | Internal Server Error        |
+| `:device_message_rate_exceeded` | Message Rate Exceeded        |
+| `:topics_message_rate_exceeded` | Topics Message Rate Exceeded |
+| `:unknown_error`                | Unknown Error                |

--- a/docs/Migrating to v1-1-0.md
+++ b/docs/Migrating to v1-1-0.md
@@ -1,6 +1,7 @@
 # Migrating to v1.1.0
 
 ## General
+
 - Kadabra has been bumped to `v0.3.1`. Minimum requirements are now Elixir
   v1.4 / OTP 19.2
 - Pushes are now synchronous by default for all services. For async
@@ -9,15 +10,19 @@
   with a `:reponse` key on the notification.
 
 ## APNS
+
 - `APNS.Config.config/1` has been renamed to `APNS.Config.new/1`
 - `[%APNS.Notification{}, ...]` is now returned instead of
   `%{ok: [...], error: [...]}` on synchronous APNS pushes.
 - `:use_2197` config option has been replaced with `:port`. APNS servers still
   only accept `443` and `2197`, but other ports may be useful for test servers.
+
 * `:reconnect` is now false by default
+
 - `push/3` removed in favor of `push/2` with options
 
 ## FCM
+
 - `FCM.NotificationResponse` has been dropped in favor of returning
   `FCM.Notification` structs with updated response keys. The old
   `NotificationResponse` keys`:ok`, `:remove`,
@@ -26,5 +31,6 @@
 - `push/3` removed in favor of `push/2` with options
 
 ## ADM
+
 - `ADM.Config.config/1` has been renamed to `ADM.Config.new/1`
 - `push/3` removed in favor of `push/2` with options

--- a/docs/Migrating to v1-1-0.md
+++ b/docs/Migrating to v1-1-0.md
@@ -16,9 +16,7 @@
   `%{ok: [...], error: [...]}` on synchronous APNS pushes.
 - `:use_2197` config option has been replaced with `:port`. APNS servers still
   only accept `443` and `2197`, but other ports may be useful for test servers.
-
-* `:reconnect` is now false by default
-
+- `:reconnect` is now false by default
 - `push/3` removed in favor of `push/2` with options
 
 ## FCM

--- a/lib/pigeon/adm/notification.ex
+++ b/lib/pigeon/adm/notification.ex
@@ -154,8 +154,7 @@ defmodule Pigeon.ADM.Notification do
       data
       |> Map.keys()
       |> Enum.sort()
-      |> Enum.map(fn key -> "#{key}:#{data[key]}" end)
-      |> Enum.join(",")
+      |> Enum.map_join(",", fn key -> "#{key}:#{data[key]}" end)
 
     md5 = :md5 |> :crypto.hash(concat) |> Base.encode64()
 

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -182,9 +182,7 @@ defmodule Pigeon.FCM do
           Process.send_after(self(), @refresh, @retry_after)
           {:noreply, %{state | retries: state.retries - 1}}
         else
-          raise "too many failed attempts to refresh, last error: #{
-                  inspect(exception)
-                }"
+          raise "too many failed attempts to refresh, last error: #{inspect(exception)}"
         end
     end
   end


### PR DESCRIPTION
Adds new CI jobs:
- Prettier - checks formatting on all JSON, YAML and Markdown files.
- Format/Credo - runs `mix format --check-formatted` and `mix credo`.

Also: cleaned up files to pass new CI jobs.