### PR TITLE
Move token generation into Pigeon.APNS.Token

### DIFF
--- a/lib/pigeon/apns/jwt_config.ex
+++ b/lib/pigeon/apns/jwt_config.ex
@@ -110,8 +110,6 @@ end
 defimpl Pigeon.Configurable, for: Pigeon.APNS.JWTConfig do
   @moduledoc false
 
-  import Joken.Config
-
   alias Pigeon.APNS.{
     ConfigParser,
     JWTConfig,
@@ -122,9 +120,6 @@ defimpl Pigeon.Configurable, for: Pigeon.APNS.JWTConfig do
   @type headers :: [{binary, binary}]
   @type sock :: {:sslsocket, any, pid | {any, any}}
   @type socket_opts :: maybe_improper_list(atom, integer | boolean)
-
-  # Seconds
-  @token_max_age 3_590
 
   # Configurable Callbacks
 
@@ -188,33 +183,8 @@ defimpl Pigeon.Configurable, for: Pigeon.APNS.JWTConfig do
 
   @spec put_bearer_token(headers, JWTConfig.t()) :: headers
   defp put_bearer_token(headers, %JWTConfig{} = config) when is_list(headers) do
-    token_storage_key = config.key_identifier <> ":" <> config.team_id
-    {timestamp, saved_token} = Pigeon.APNS.Token.get(token_storage_key)
-    now = :os.system_time(:seconds)
-
-    token =
-      case now - timestamp do
-        age when age < @token_max_age -> saved_token
-        _ -> generate_apns_jwt(config, token_storage_key)
-      end
+    token = Pigeon.APNS.Token.get(config)
 
     [{"authorization", "bearer " <> token} | headers]
-  end
-
-  @spec generate_apns_jwt(JWTConfig.t(), binary) :: binary
-  defp generate_apns_jwt(config, token_storage_key) do
-    key = %{"pem" => config.key}
-    now = :os.system_time(:seconds)
-
-    signer =
-      Joken.Signer.create("ES256", key, %{"kid" => config.key_identifier})
-
-    {:ok, token, _claims} =
-      default_claims(iss: config.team_id, iat: now)
-      |> Joken.generate_and_sign(%{}, signer)
-
-    :ok = Pigeon.APNS.Token.update(token_storage_key, {now, token})
-
-    token
   end
 end

--- a/lib/pigeon/apns/token.ex
+++ b/lib/pigeon/apns/token.ex
@@ -1,5 +1,11 @@
 defmodule Pigeon.APNS.Token do
   @moduledoc false
+  import Joken.Config
+
+  alias Pigeon.APNS.JWTConfig
+
+  # seconds - 10 seconds short of one hour
+  @token_max_age 3_590
 
   @type t :: {non_neg_integer(), binary() | nil}
 
@@ -18,13 +24,36 @@ defmodule Pigeon.APNS.Token do
     }
   end
 
-  @spec get(String.t()) :: t
-  def get(name) do
-    Agent.get(__MODULE__, &Map.get(&1, name, {0, nil}))
+  @spec get(JWTConfig.t()) :: t
+  def get(%JWTConfig{} = config) do
+    token_storage_key = config.key_identifier <> ":" <> config.team_id
+
+    Agent.get_and_update(__MODULE__, fn map ->
+      {timestamp, saved_token} = Map.get(map, token_storage_key, {0, nil})
+      now = :os.system_time(:seconds)
+
+      age = now - timestamp
+      if age < @token_max_age do
+        {saved_token, map}
+      else
+        token = generate_apns_jwt(config)
+        {token, Map.put(map, token_storage_key, {now, token})}
+      end
+    end)
   end
 
-  @spec update(String.t(), t) :: :ok
-  def update(name, token) do
-    Agent.update(__MODULE__, &Map.put(&1, name, token))
+  @spec generate_apns_jwt(JWTConfig.t()) :: binary
+  defp generate_apns_jwt(config) do
+    key = %{"pem" => config.key}
+    now = :os.system_time(:seconds)
+
+    signer =
+      Joken.Signer.create("ES256", key, %{"kid" => config.key_identifier})
+
+    {:ok, token, _claims} =
+      default_claims(iss: config.team_id, iat: now)
+      |> Joken.generate_and_sign(%{}, signer)
+
+    token
   end
 end


### PR DESCRIPTION
This ensures the token is only generated once and used across all workers
This fixes #226 