### PR TITLE
Add typespecs for success and failure cases on FCM

### DIFF
--- a/lib/pigeon/fcm/notification.ex
+++ b/lib/pigeon/fcm/notification.ex
@@ -31,6 +31,18 @@ defmodule Pigeon.FCM.Notification do
           webpush: map | nil
         }
 
+  @type success :: %__MODULE__{
+          __meta__: Pigeon.Metadata.t(),
+          name: binary,
+          response: :success
+        }
+
+  @type errored :: %__MODULE__{
+          __meta__: Pigeon.Metadata.t(),
+          error: map,
+          response: error_response
+        }
+
   @type error_response ::
           :unspecified_error
           | :invalid_argument


### PR DESCRIPTION
## Context
I think it's helpful to see these as types in the code itself versus only in the description of the docs.

> On successful response, :name will be set to the name returned from the FCM API and :response will be :success. If there was an error, :error will contain a JSON map of the response and :response will be an atomized version of the error type.