### PR TITLE
feat: support for Goth modules for FCM

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -33,6 +33,6 @@ config :pigeon, PigeonTest.LegacyFCM,
 config :pigeon, PigeonTest.FCM,
   adapter: Pigeon.FCM,
   project_id: System.get_env("FCM_PROJECT"),
-  goth: PigeonTest.Goth
+  token_fetcher: PigeonTest.Goth
 
 config :pigeon, PigeonTest.Sandbox, adapter: Pigeon.Sandbox

--- a/config/test.exs
+++ b/config/test.exs
@@ -33,6 +33,6 @@ config :pigeon, PigeonTest.LegacyFCM,
 config :pigeon, PigeonTest.FCM,
   adapter: Pigeon.FCM,
   project_id: System.get_env("FCM_PROJECT"),
-  service_account_json: System.get_env("FCM_SERVICE_ACCOUNT_JSON")
+  goth: PigeonTest.Goth
 
 config :pigeon, PigeonTest.Sandbox, adapter: Pigeon.Sandbox

--- a/lib/pigeon/dispatcher.ex
+++ b/lib/pigeon/dispatcher.ex
@@ -13,7 +13,7 @@ defmodule Pigeon.Dispatcher do
   opts = [
     adapter: Pigeon.FCM,
     project_id: "example-project-123",
-    service_account_json: File.read!("service-account.json")
+    token_fetcher: YourApp.Goth
   ]
 
   {:ok, pid} = Pigeon.Dispatcher.start_link(opts)
@@ -33,6 +33,7 @@ defmodule Pigeon.Dispatcher do
     @doc false
     def start(_type, _args) do
       children = [
+        {Goth, name: YourApp.Goth},
         YourApp.Repo,
         {Registry, keys: :unique, name: Registry.YourApp}
       ] ++ push_workers()
@@ -62,7 +63,7 @@ defmodule Pigeon.Dispatcher do
         adapter: Pigeon.FCM,
         name: {:via, Registry, {Registry.YourApp, config.name}},
         project_id: config.project_id,
-        service_account_json: config.service_account_json
+        token_fetcher: String.to_existing_atom(config.token_fetcher)
       ]}
     end
   end

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -13,15 +13,16 @@ defmodule Pigeon.FCM do
   end
   ```
 
-  2. (Optional) Add configuration to your `config.exs`.
+  2. Configure [`goth`](https://hexdocs.pm/goth/1.4.3/readme.html#installation), and add it to `config.exs`
 
   ```
   # config.exs
+  # See Step 3 for alternative configuration
 
   config :your_app, YourApp.FCM,
     adapter: Pigeon.FCM,
     project_id: "example-project-123",
-    service_account_json: File.read!("service-account.json")
+    token_fetcher: YourApp.Goth
   ```
 
   3. Start your dispatcher on application boot.
@@ -35,6 +36,7 @@ defmodule Pigeon.FCM do
     @doc false
     def start(_type, _args) do
       children = [
+        {Goth, name: YourApp.Goth},
         YourApp.FCM
       ]
       opts = [strategy: :one_for_one, name: YourApp.Supervisor]
@@ -43,7 +45,7 @@ defmodule Pigeon.FCM do
   end
   ```
 
-  If you skipped step two, include your configuration.
+  If preferred, you can include your configuration directly
 
   ```
   defmodule YourApp.Application do
@@ -54,6 +56,7 @@ defmodule Pigeon.FCM do
     @doc false
     def start(_type, _args) do
       children = [
+        {Goth, name: YourApp.Goth},
         {YourApp.FCM, fcm_opts()}
       ]
       opts = [strategy: :one_for_one, name: YourApp.Supervisor]
@@ -64,7 +67,7 @@ defmodule Pigeon.FCM do
       [
         adapter: Pigeon.FCM,
         project_id: "example-project-123",
-        service_account_json: File.read!("service-account.json")
+        token_fetcher: YourApp.Goth
       ]
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,8 @@ defmodule Pigeon.Mixfile do
           Pigeon.FCM,
           Pigeon.FCM.Notification,
           Pigeon.LegacyFCM,
-          Pigeon.LegacyFCM.Notification
+          Pigeon.LegacyFCM.Notification,
+          PigeonTest.GothHttpClient.Stub
         ]
       ],
       main: "Pigeon"

--- a/test/pigeon/fcm_test.exs
+++ b/test/pigeon/fcm_test.exs
@@ -9,7 +9,7 @@ defmodule Pigeon.FCMTest do
 
   @data %{"message" => "Test push"}
   @invalid_project_msg ~r/^attempted to start without valid :project_id/
-  @invalid_service_account_json_msg ~r/^attempted to start without valid :service_account_json/
+  @invalid_goth_msg ~r/^attempted to start without valid :goth module/
 
   defp valid_fcm_reg_id do
     Application.get_env(:pigeon, :test)[:valid_fcm_reg_id]
@@ -18,14 +18,14 @@ defmodule Pigeon.FCMTest do
   describe "init/1" do
     test "raises if configured with invalid project" do
       assert_raise(Pigeon.ConfigError, @invalid_project_msg, fn ->
-        [project_id: nil, service_account_json: "{}"]
+        [project_id: nil, goth: PigeonTest.Goth]
         |> Pigeon.FCM.init()
       end)
     end
 
-    test "raises if configured with invalid service account JSON" do
-      assert_raise(Pigeon.ConfigError, @invalid_service_account_json_msg, fn ->
-        [project_id: "example", service_account_json: nil]
+    test "raises if configured with invalid goth module" do
+      assert_raise(Pigeon.ConfigError, @invalid_goth_msg, fn ->
+        [project_id: "example", goth: nil]
         |> Pigeon.FCM.init()
       end)
     end
@@ -52,6 +52,7 @@ defmodule Pigeon.FCMTest do
       assert n.response == :success
     end
 
+    @tag :focus
     test "successfully sends a valid push with a dynamic dispatcher" do
       target = {:token, valid_fcm_reg_id()}
       n = Notification.new(target, %{}, @data)

--- a/test/pigeon/fcm_test.exs
+++ b/test/pigeon/fcm_test.exs
@@ -9,7 +9,7 @@ defmodule Pigeon.FCMTest do
 
   @data %{"message" => "Test push"}
   @invalid_project_msg ~r/^attempted to start without valid :project_id/
-  @invalid_goth_msg ~r/^attempted to start without valid :goth module/
+  @invalid_fetcher_msg ~r/^attempted to start without valid :token_fetcher module/
 
   defp valid_fcm_reg_id do
     Application.get_env(:pigeon, :test)[:valid_fcm_reg_id]
@@ -18,14 +18,14 @@ defmodule Pigeon.FCMTest do
   describe "init/1" do
     test "raises if configured with invalid project" do
       assert_raise(Pigeon.ConfigError, @invalid_project_msg, fn ->
-        [project_id: nil, goth: PigeonTest.Goth]
+        [project_id: nil, token_fetcher: PigeonTest.Goth]
         |> Pigeon.FCM.init()
       end)
     end
 
-    test "raises if configured with invalid goth module" do
-      assert_raise(Pigeon.ConfigError, @invalid_goth_msg, fn ->
-        [project_id: "example", goth: nil]
+    test "raises if configured with invalid token_fetcher module" do
+      assert_raise(Pigeon.ConfigError, @invalid_fetcher_msg, fn ->
+        [project_id: "example", token_fetcher: nil]
         |> Pigeon.FCM.init()
       end)
     end

--- a/test/support/fcm.ex
+++ b/test/support/fcm.ex
@@ -7,3 +7,51 @@ defmodule PigeonTest.LegacyFCM do
   @moduledoc false
   use Pigeon.Dispatcher, otp_app: :pigeon
 end
+
+defmodule PigeonTest.GothHttpClient.Stub do
+  @moduledoc """
+  A collection of functions that can be used as custom `:http_client` values. Used to avoid
+  calling out to GCP during tests.
+  """
+
+  @doc """
+  Always returns a stub access_token response, as if being requested of a Google Metadata Server
+
+  ## Usage
+  ```
+  goth_opts = [
+    name: PigeonTest.Goth,
+    source: {:metadata, []}
+    http_client: {&PigeonTest.GothHttpClient.Stub.access_token_response/1, []}
+  ]
+
+  fcm_opts = [
+    adapter: Pigeon.Sandbox,
+    project_id: "example-123",
+    goth: PigeonTest.Goth
+  ]
+
+  children = [
+    {Goth, goth_opts}
+    {PigeonTest.FCM, fcm_opts}
+  ]
+
+  Supervisor.start_link(children, strategy: :one_for_one)
+  """
+  @spec access_token_response(keyword()) ::
+          {:ok,
+           %{
+             status: pos_integer(),
+             headers: list(),
+             body: String.t()
+           }}
+  def access_token_response(_) do
+    body = %{
+      "access_token" => "FAKE_APPLICATION_DEFAULT_CREDENTIALS_ACCESS_TOKEN",
+      "expires_in" => :timer.minutes(30),
+      "token_type" => "Bearer"
+    }
+
+    {:ok, %{status: 200, headers: [], body: Jason.encode!(body)}}
+  end
+end

--- a/test/support/fcm.ex
+++ b/test/support/fcm.ex
@@ -32,23 +32,23 @@ defmodule PigeonTest.GothHttpClient.Stub do
   end
 
   # config/test.exs
-
   # Config for the Goth genserver, YourApp.Goth
   config :your_app, YourApp.Goth,
     source: {:metadata, []},
     http_client: {&PigeonTest.GothHttpClient.Stub.access_token_response/1, []}
-  ```
+
 
   # application.exs
   def start(_type, _args) do
-      children = [
-        # The `child_spec/1` handles fetching the proper config
-        YourApp.Goth,
-        YourApp.FCM
-      ]
-      opts = [strategy: :one_for_one, name: YourApp.Supervisor]
-      Supervisor.start_link(children, opts)
-    end
+    children = [
+      # The `child_spec/1` handles fetching the proper config
+      YourApp.Goth,
+      YourApp.FCM
+    ]
+    opts = [strategy: :one_for_one, name: YourApp.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+  ```
   """
 
   @doc """

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,13 @@
 ExUnit.start(capture_log: true)
 
+fcm_credentials =
+  System.fetch_env!("FCM_SERVICE_ACCOUNT_FILE")
+  |> File.read!()
+  |> Jason.decode!()
+  |> Map.fetch!("source_credentials")
+
 workers = [
+  {Goth, name: PigeonTest.Goth, source: {:refresh_token, fcm_credentials}},
   PigeonTest.ADM,
   PigeonTest.APNS,
   PigeonTest.APNS.JWT,


### PR DESCRIPTION
closes #232

Updates the `Pigeon.FCM` and `Pigeon.FCM.Config` implementations to delegate the token refresh logic to `Goth`, as Goth v1.3+ now handles that directly
