### PR TITLE
Relax Poison dependency to allow 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Relax Poison dependency to allow 5.x
+
 ## v1.6.1
 
 **Security**

--- a/mix.exs
+++ b/mix.exs
@@ -59,7 +59,7 @@ defmodule Pigeon.Mixfile do
       {:httpoison, "~> 0.7 or ~> 1.0"},
       {:joken, "~> 2.1"},
       {:kadabra, "~> 0.6.0", optional: true},
-      {:poison, "~> 2.0 or ~> 3.0 or ~> 4.0"}
+      {:poison, "~> 2.0 or ~> 3.0 or ~> 4.0 or ~> 5.0"}
     ]
   end
 


### PR DESCRIPTION
This is a small update to the 1.6 branch.

I'm not quite ready to jump to the 2.x rc.

