### PR TITLE
fix: use uri to make token storage key unique

### DIFF
--- a/lib/pigeon/apns/jwt_config.ex
+++ b/lib/pigeon/apns/jwt_config.ex
@@ -78,11 +78,11 @@ defmodule Pigeon.APNS.JWTConfig do
       ...>   ping_period: 300_000
       ...> )
       %Pigeon.APNS.JWTConfig{
-        uri: "api.push.apple.com",
-        team_id: "DEF1234567",
-        key_identifier: "ABC1234567",
+        uri: "api.push.apple.com", 
+        team_id: "DEF1234567", 
+        key_identifier: "ABC1234567", 
         key: File.read!("test/support/FakeAPNSAuthKey.p8"),
-        ping_period: 300000,
+        ping_period: 300000, 
         port: 2197
       }
   """


### PR DESCRIPTION
We noticed there was an issue where fetching tokens for our development pushes were causing some conflicts with our pushes to release devices. This is a simple fix to ensure that the token generated for `:dev` or `:prod` have their own unique token lifecycle, since apple is finicky about how many times you request a token. It has been a bit since we made this fix but never got around to upstreaming it, so I forget the details on _what_ error we were seeing a lot of.