### PR TITLE
Fix Mix Deps Version Conflicts (Remove Match on `~> 0.7` for `httpoison`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule Pigeon.Mixfile do
       {:excoveralls, "~> 0.5", only: :test, runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:goth, "~> 1.3.0"},
-      {:httpoison, "~> 0.7 or ~> 1.0 or ~> 2.0"},
+      {:httpoison, "~> 1.0 or ~> 2.0"},
       {:jason, "~> 1.0", optional: true},
       {:joken, "~> 2.1"},
       {:kadabra, "~> 0.6.0"}


### PR DESCRIPTION
It appears that Mix only looks at the first two conditions here:
```elixir
{:httpoison, "~> 0.7 or ~> 1.0 or ~> 2.0"},
```

so it ends up failing for `httpoison` versions >= 2.0 when other deps require it:

![image](https://github.com/codedge-llc/pigeon/assets/1571956/e57a2b8c-650f-4478-962a-abd0c42417c1)
```bash
> mix deps.get
Resolving Hex dependencies...
Resolution completed in 0.121s
Because openai >= 0.4.2 depends on httpoison ~> 2.0 and pigeon >= 1.1.5 depends on httpoison ~> 0.7 or ~> 1.0, openai >= 0.4.2 is incompatible with pigeon >= 1.1.5.
And because your app depends on openai ~> 0.5.3, pigeon >= 1.1.5 is forbidden.
So, because your app depends on pigeon ~> 2.0.0-rc.1, version solving failed.
```