### PR TITLE
fix: DispatchWorker missing a 2-element stop clause in handle_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Changed**
 
 - Bump `goth` dependency to `~> 1.4.3`. ([#252](https://github.com/codedge-llc/pigeon/pull/252))
+- Fix `DispatcherWorker` missing a clause for `{:stop, reason}` in the handle_info function.
 
 ## v2.0.0-rc.2
 

--- a/lib/pigeon/adapter.ex
+++ b/lib/pigeon/adapter.ex
@@ -46,14 +46,15 @@ defmodule Pigeon.Adapter do
   @callback init(opts :: Keyword.t()) :: {:ok, any} | {:stop, any}
 
   @doc """
-  Invoked to handle all other messages.
-  """
-  @callback handle_info(term, term) :: {:noreply, term}
-
-  @doc """
   Invoked to handle push notifications.
   """
   @callback handle_push(notification :: struct | [struct], state :: term) ::
               {:noreply, new_state :: term}
               | {:stop, reason :: term, new_state :: term}
+
+  @doc """
+  Invoked to handle all other messages.
+  """
+  @callback handle_info(term, term) ::
+              {:noreply, term} | {:stop, reason :: term}
 end

--- a/lib/pigeon/dispatcher_worker.ex
+++ b/lib/pigeon/dispatcher_worker.ex
@@ -39,6 +39,9 @@ defmodule Pigeon.DispatcherWorker do
       {:noreply, new_state} ->
         {:noreply, %{adapter: adapter, state: new_state}}
 
+      {:stop, reason} ->
+        {:stop, reason, %{adapter: adapter, state: state}}
+
       {:stop, reason, new_state} ->
         {:stop, reason, %{adapter: adapter, state: new_state}}
     end


### PR DESCRIPTION
As pointed out in the #203 ([comment](https://github.com/codedge-llc/pigeon/issues/203#issuecomment-2186245808)), the `{:stop, reason}` clause is missing, which leads to `CaseClauseError`s instead of proper error handling.

I also moved the `handle_info` callback below `handle_push` as it mentions "all other messages", which logically should be a follow-up to what handle_push` has in its doc.

As a side note,  I couldn't find a case in which `{:stop, reason, new_state}` for `handle_info` is invoked, but I didn't want to accidentally break anything, so I left it as it was :)