### PR TITLE
Macro.underscore - no match of right hand side value: nil

### DIFF
--- a/lib/pigeon/legacy_fcm/config.ex
+++ b/lib/pigeon/legacy_fcm/config.ex
@@ -167,7 +167,7 @@ defimpl Pigeon.Configurable, for: Pigeon.LegacyFCM.Config do
   def parse_error(data) do
     case Pigeon.json_library().decode(data) do
       {:ok, response} ->
-        response["reason"] |> Macro.underscore() |> String.to_existing_atom()
+        (response["reason"] || "unknown") |> Macro.underscore() |> String.to_existing_atom()
 
       error ->
         "JSON parse failed: #{inspect(error)}, body: #{inspect(data)}"


### PR DESCRIPTION
Fix for #265

Adds an "unknown" response if the response error is nil 