### PR TITLE
Fix Elixir 1.17 deprecation

### DIFF
--- a/lib/pigeon/application.ex
+++ b/lib/pigeon/application.ex
@@ -7,7 +7,7 @@ defmodule Pigeon.Application do
 
   @doc false
   def start(_type, _args) do
-    Client.default().start
+    Client.default().start()
 
     children = [
       Pigeon.Registry,


### PR DESCRIPTION
This was fixed in the 1.6 branch, but not in master.

Fixes the warning
```
warning: using map.field notation (without parentheses) to invoke function Pigeon.Http2.Client.Kadabra.start() is deprecated, you must add parentheses instead: remote.function()
Warning:   (pigeon 1.6.2) lib/pigeon.ex:16: Pigeon.start/2
```