### PR TITLE
Fix compilation warning for Elixir 1.18

### DIFF
--- a/lib/pigeon/apns/config_parser.ex
+++ b/lib/pigeon/apns/config_parser.ex
@@ -29,15 +29,15 @@ defmodule Pigeon.APNS.ConfigParser do
           reason: "configuration is invalid",
           config: opts
 
-      type ->
+      {:ok, type} ->
         type.new(opts)
     end
   end
 
-  @spec config_type(any) :: module | :error
+  @spec config_type(any) :: {:ok, module} | :error
   defp config_type(%{cert: _cert, key_identifier: _key_id}), do: :error
-  defp config_type(%{cert: _cert}), do: Config
-  defp config_type(%{key_identifier: _jwt_key}), do: JWTConfig
+  defp config_type(%{cert: _cert}), do: {:ok, Config}
+  defp config_type(%{key_identifier: _jwt_key}), do: {:ok, JWTConfig}
   defp config_type(_else), do: :error
 
   @doc false


### PR DESCRIPTION
The following warning triggers on Elixir 1.18:

```
Compiling 1 file (.ex)
    warning: :error.new/1 is undefined (module :error is not available or is yet to be defined)
    │
 33 │         type.new(opts)
    │              ~
    │
    └─ lib/pigeon/apns/config_parser.ex:33:14: Pigeon.APNS.ConfigParser.parse/1
```

The solution was suggested here: https://github.com/elixir-lang/elixir/issues/14043