### PR TITLE
docs: refactor CHANGELOG v1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,17 @@
 # Changelog
 
-## 1.6.3
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 1.6.3 - 2024-08-12
 
 **Fixed**
 
 - Clean up Elixir 1.17 deprecation warnings ([#262](https://github.com/codedge-llc/pigeon/pull/262)).
 
-## 1.6.2
+## 1.6.2 - 2024-01-17
 
 **Changed**
 
@@ -17,17 +22,17 @@
 
 - Handle new PEM decode case for APNS cert keys with OpenSSL 3.0.
 
-## v1.6.1
+## v1.6.1 - 2021-05-31
 
 **Security**
 
 - Bump minimum Kadabra to 0.6.0. This is a critical security update for CA certificate validation.
 
-## v1.6.0
+## v1.6.0 - 2021-01-09
 
 **Added**
 
-- JSON library made configurable. For backwards compatability, Poison is still a required dependency.
+- JSON library made configurable. For backwards compatibility, Poison is still a required dependency.
   Override in your `config.exs`.
 
   ```
@@ -38,12 +43,12 @@
 
 - Handle FCM single message_id's on topic pushes.
 
-## v1.5.1
+## v1.5.1 - 2020-05-25
 
 - Added APNS InvalidPushType error ([#172](https://github.com/codedge-llc/pigeon/pull/172)).
 - Fixed various typespecs ([#170](https://github.com/codedge-llc/pigeon/pull/170)).
 
-## v1.5.0
+## v1.5.0 - 2020-02-17
 
 - Bumped minimum Elixir version to 1.6
 - Raise `Pigeon.ConfigError` when booting invalid config structs.
@@ -63,83 +68,83 @@ Possible error values:
 - `{:error, {:invalid, value}}`
 - `{:error, {:nofile, value}}`
 
-## v1.4.0
+## v1.4.0 - 2019-10-13
 
 - `apns-push-type` header support for iOS 13. An additional `:push_type` key has been
   added to the `APNS.Notification` struct.
 
-## v1.3.2
+## v1.3.2 - 2019-08-17
 
 - Document workers configuration for run-time configuration of push workers.
 - Modify run-time configuration of push workers so that multiple (or no)
   workers may be returned by the startup configuration.
 
-## v1.3.1
+## v1.3.1 - 2019-06-06
 
 - Joken dependency bumped to 2.1
 
-## v1.3.0
+## v1.3.0 - 2019-03-14
 
 - Support for FCM `content_available`, `mutable_content`, and `condition` keys
 - Set `priority` of APNS notifications
 - Joken dependency bumped to 2.0.1
 
-## v1.2.4
+## v1.2.4 - 2018-10-15
 
 - Fixed ADM handling of connection timeouts
 
-## v1.2.3
+## v1.2.3 - 2018-09-17
 
 - Fixed APNS, FCM and ADM error response parse crashes. Error responses not
   listed in the documentation are returned as `:unknown_error`
 
-## v1.2.2
+## v1.2.2 - 2018-07-08
 
 - Fixed APNS handling of notification `expiration`
 - Added APNS support for `collapse_id`
 
-## v1.2.1
+## v1.2.1 - 2018-07-06
 
 - FCM notifications can now handle `time_to_live`, `collapse_key`, `restricted_package_name`
   and `dry_run` keys
 
-## v1.2.0
+## v1.2.0 - 2018-05-25
 
 - Support for APNS JWT configuration
 - Bump `kadabra` dependency to `v0.4.2`
 
-## v1.1.6
+## v1.1.6 - 2018-02-12
 
 - Relax `gen_stage` dependency to `~> 0.12`
 - Bump `kadabra` dependency to `v0.3.7`
 
-## v1.1.5
+## v1.1.5 - 2018-01-31
 
 - Fix: relax `httpoison` dependency to allow `0.x` or `1.0`
 
-## v1.1.4
+## v1.1.4 - 2018-01-03
 
 - Fix: `:on_response` callbacks spawned as supervised task instead of running
   in the `Worker` process
 - Fix: ADM token refresh failure returns updated notification instead of
   error tuple
 
-## v1.1.3
+## v1.1.3 - 2017-12-23
 
 - More robust FCM/APNS backpressure
 - Bumped minimum Kadabra version to `v0.3.6`
 
-## v1.1.2
+## v1.1.2 - 2017-12-04
 
 - Auto-restart connections if max stream ID is reached
 - FCM/APNS Workers now use GenStage to queue pending pushes
 - Bumped minimum Kadabra version to `v0.3.5`
 
-## v1.1.1
+## v1.1.1 - 2017-10-31
 
 - Bumped minimum Kadabra version to `v0.3.4`
 
-## v1.1.0
+## v1.1.0 - 2017-10-01
 
 - Minimum requirements now Elixir v1.4 and OTP 19.2 (Kadabra bumped
   to `v0.3.0`)
@@ -180,24 +185,24 @@ config :pigeon, workers: [
   the notification.
 - `ADM.start_connection/1` and `ADM.stop_connection/1` added
 
-## v1.0.4
+## v1.0.4 - 2017-09-06
 
 - Fix: removed connection pinging from FCM.Worker (`:ping_period` option
   left in FCM config to not break API)
 
-## v1.0.3
+## v1.0.3 - 2017-08-03
 
 - Fixed proper handling of large FCM push batches
 
-## v1.0.2
+## v1.0.2 - 2017-08-01
 
 - Fixed FCM infinite `GOAWAY session_timed_out` loop
 
-## v1.0.1
+## v1.0.1 - 2017-08-01
 
 - Configurable `:ping_period` for FCM connections
 
-## v1.0.0
+## v1.0.0 - 2017-07-30
 
 - GCM migrated to FCM API (http2)
 - `GCM` modules renamed to `FCM`
@@ -206,100 +211,6 @@ config :pigeon, workers: [
 - Disable auto-reconnect for APNS workers with `reconnect: false`
 - Removed Chatterbox http2 client adapter
 
-## v0.13.0
+## Previous versions
 
-- Configurable `:ping_period` for APNS connections
-
-## v0.12.1
-
-- Various `chatterbox` client adapter fixes
-
-## V0.12.0
-
-- Configurable `Pigeon.Http2.Client`. Currently supports `kadabra`
-  and `chatterbox`
-- `kadabra` bumped to `v0.2.0`
-
-## v0.11.0
-
-- APNS workers can be started and referenced with pids and/or atom names
-- Fix: Push `:name` option renamed to `:to`
-- Fix: GCM/ADM async pushes now use `spawn/1` instead of `Task.async/1`
-
-## v0.10.3
-
-- Fix: cleaned up Elixir v1.4 warnings
-
-## v0.10.2
-
-- Fix: poison dependency version made optionally `~> 2.0 or ~> 3.0`
-
-## v0.10.1
-
-- Fix: kadabra not started
-
-## v0.10.0
-
-- Migrated HTTP/2 client from `chatterbox` to `kadabra`
-- Support for ADM (Amazon Android) push
-- APNS pushes are now synchronous by default. For async pushes use the
-  new `on_response` option. GCM and ADM will have it in the next major release.
-- Bulk APNS pushing
-- Handling of multiple APNS worker connections with different configs
-- Re-implemented APNS socket pings to keep connections open
-- `:invalid_jSON` corrected to `:invalid_json`
-
-## v0.9.2
-
-- Fixed GCM error response atom conversion
-
-## v0.9.1
-
-- Fixed :eaddrinuse error when restarting Pigeon too quickly with
-  :apns_2197 enabled
-
-## v0.9.0
-
-- APNS topic made optional
-- APNS `put_mutable_content` helper function added
-- GCM can be configured on a per-push basis
-- Updated to use Macro.underscore
-
-## v0.8.0
-
-- Implemented Chatterbox as APNS HTTP2 client
-- APNS server responses now caught asynchronously
-- GCM support for `notification` and `data` payload keys
-  (`Pigeon.GCM.Notification.new` API changes)
-
-## v0.7.0
-
-- APNS cert/key configs can now either be a file path, full-text string,
-  or `{:your_app, "path/to/file.pem"}` (which looks in the `/priv` directory
-  of your app)
-- Fixed APNSWorker crash on `:ssl.send/2` timeout
-- Better error-handling for invalid APNS configs
-
-## v0.6.0
-
-- `Pigeon.APNS.Notification.new/3` returns `%Pigeon.APNS.Notification{}` struct
-- Configure APNS to use SSL port 2197 with `apns_2197: true` in
-  your `config.exs`
-- Error feedback symbols converted from `CamelCase` to `snake_case`
-- APNS expiration values supported with `expiration` key in
-  `%Pigeon.APNS.Notification{}`
-
-## v0.5.2
-
-- Fixed bug where APNSWorker would hang up if SSL connection failed. Now
-  retries the connection twice more before gracefully shutting down.
-
-## v0.5.1
-
-- GCM error responses return proper chunk of regstration IDs
-
-## v0.5.0
-
-- `Pigeon.GCM.Notification.new/2` returns `%Pigeon.GCM.Notification{}` struct
-- Multiple registration IDs allowed in `Pigeon.GCM.push/2`
-- Remove `:gcm_worker`
+- See the CHANGELOG.md [in the v0.13 branch](https://github.com/codedge-llc/pigeon/blob/v0.13/CHANGELOG.md)


### PR DESCRIPTION
Cleaning up CHANGELOG across major versions.