### PR TITLE
fix: minor fixes to Pigeon typespecs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.0-otp-27
-erlang 27.0.1
+elixir 1.18.3-otp-27
+erlang 27.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Return `:permission_denied` FCM error response if missing privileges. ([#290](https://github.com/codedge-llc/pigeon/pull/290))
 - Better handling of FCM errors with multiple details. ([#293](https://github.com/codedge-llc/pigeon/pull/293))
-- Minor documentation fixes. ([#294](https://github.com/codedge-llc/pigeon/pull/294))
+- Minor documentation and typespec fixes. ([#294](https://github.com/codedge-llc/pigeon/pull/294), [#297](https://github.com/codedge-llc/pigeon/pull/297))
 
 ## v2.0.1 - 2024-12-28
 

--- a/lib/pigeon.ex
+++ b/lib/pigeon.ex
@@ -66,36 +66,36 @@ defmodule Pigeon do
   - `:timeout` - Push timeout. Defaults to 5000ms.
   """
   @type push_opts :: [
-          on_response: on_response | nil,
-          timeout: non_neg_integer
+          on_response: on_response() | nil,
+          timeout: non_neg_integer()
         ]
 
   @doc """
   Returns the configured default pool size for Pigeon dispatchers.
+
   To customize this value, include the following in your config/config.exs:
 
       config :pigeon, :default_pool_size, 5
   """
-  @spec default_pool_size :: pos_integer
+  @spec default_pool_size :: pos_integer()
   def default_pool_size() do
     Application.get_env(:pigeon, :default_pool_size, 5)
   end
 
   @doc """
   Returns the configured JSON encoding library for Pigeon.
+
   To customize the JSON library, include the following in your config/config.exs:
 
       config :pigeon, :json_library, Jason
   """
-  @spec json_library :: module
+  @spec json_library :: module()
   def json_library do
     Application.get_env(:pigeon, :json_library, Jason)
   end
 
-  @spec push(pid | atom, notification :: notification, push_opts) ::
-          notification :: struct | no_return
-  @spec push(pid | atom, notifications :: [notification, ...], push_opts) ::
-          notifications :: [struct, ...] | no_return
+  @spec push(pid() | atom(), notification() | [notification()], push_opts()) ::
+          notification() | :ok
   @doc """
   Sends a push notification with given options.
   """

--- a/lib/pigeon.ex
+++ b/lib/pigeon.ex
@@ -95,7 +95,7 @@ defmodule Pigeon do
   end
 
   @spec push(pid() | atom(), notification() | [notification()], push_opts()) ::
-          notification() | :ok
+          notification() | [notification()] | :ok | [:ok]
   @doc """
   Sends a push notification with given options.
   """


### PR DESCRIPTION
Defines one `@spec` now for `Pigeon.push/3` with more accurate types. Also adjusted `@doc`s on some of the other functions.