### PR TITLE
Fix socket not reconnecting

### DIFF
--- a/lib/pigeon.ex
+++ b/lib/pigeon.ex
@@ -67,6 +67,7 @@ defmodule Pigeon do
   """
   @type push_opts :: [
           on_response: on_response() | nil,
+          impl: atom() | nil,
           timeout: non_neg_integer()
         ]
 
@@ -108,7 +109,15 @@ defmodule Pigeon do
   def push(pid, notification, opts) do
     if Keyword.has_key?(opts, :on_response) do
       on_response = Keyword.get(opts, :on_response)
-      notification = put_on_response(notification, on_response)
+      impl = Keyword.get(opts, :impl)
+      current_try = Keyword.get(opts, :current_try)
+
+      notification =
+        notification
+        |> put_on_response(on_response)
+        |> put_impl(impl)
+        |> put_current_try(current_try)
+
       push_async(pid, notification)
     else
       timeout = Keyword.get(opts, :timeout, @default_timeout)
@@ -142,8 +151,24 @@ defmodule Pigeon do
     end
   end
 
+  defp put_on_response(notification, nil), do: notification
+
   defp put_on_response(notification, on_response) do
     meta = %{notification.__meta__ | on_response: on_response}
+    %{notification | __meta__: meta}
+  end
+
+  defp put_impl(notification, nil), do: notification
+
+  defp put_impl(notification, impl) do
+    meta = %{notification.__meta__ | impl: impl}
+    %{notification | __meta__: meta}
+  end
+
+  defp put_current_try(notification, nil), do: notification
+
+  defp put_current_try(notification, current_try) do
+    meta = %{notification.__meta__ | current_try: current_try}
     %{notification | __meta__: meta}
   end
 end

--- a/lib/pigeon/adapter_helper.ex
+++ b/lib/pigeon/adapter_helper.ex
@@ -1,0 +1,91 @@
+defmodule Pigeon.AdapterHelper do
+  @moduledoc false
+
+  alias Pigeon.Configurable
+  alias Pigeon.HTTP.RequestQueue
+
+  @max_retries 3
+
+  @doc """
+  Checks if the socket is open before sending the request.
+  If the socket is closed, requeues the notification and attempts to reconnect.
+  """
+  def handle_push(notification, state, request_fn) do
+    %{socket: socket} = state
+
+    Mint.HTTP.open?(socket)
+    |> if do
+      do_request(notification, state, request_fn)
+    else
+      requeue_notification(notification)
+      reconnect_or_exit(state)
+    end
+  end
+
+  defp do_request(notification, state, request_fn) do
+    %{config: config, queue: queue, socket: socket} = state
+    headers = Configurable.push_headers(config, notification, [])
+    payload = Configurable.push_payload(config, notification, [])
+
+    {method, path} = request_fn.(config, notification)
+
+    Mint.HTTP.request(socket, method, path, headers, payload)
+    |> case do
+      {:ok, socket, ref} ->
+        new_q = RequestQueue.add(queue, ref, notification)
+
+        state =
+          state
+          |> Map.put(:socket, socket)
+          |> Map.put(:queue, new_q)
+
+        {:noreply, state}
+
+      _ ->
+        requeue_notification(notification)
+
+        {:noreply, state}
+    end
+  end
+
+  def connect_socket(config, retries \\ @max_retries) do
+    case Configurable.connect(config) do
+      {:ok, socket} ->
+        {:ok, socket}
+
+      {:error, reason} ->
+        if retries > 0 do
+          connect_socket(config, retries - 1)
+        else
+          {:error, reason}
+        end
+    end
+  end
+
+  def requeue_notification(%{__meta__: %{impl: impl}} = notification)
+      when is_atom(impl) and not is_nil(impl) do
+    opts = notification.__meta__ |> Map.from_struct() |> Map.to_list()
+
+    apply(impl, :push, [
+      notification,
+      opts
+    ])
+  end
+
+  def requeue_notification(_notification) do
+    :ok
+  end
+
+  def reconnect_or_exit(state) do
+    %{config: config} = state
+
+    case connect_socket(config) do
+      {:ok, socket} ->
+        Configurable.schedule_ping(config)
+        {:noreply, %{state | socket: socket}}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
+  end
+end

--- a/lib/pigeon/adm.ex
+++ b/lib/pigeon/adm.ex
@@ -65,8 +65,8 @@ defmodule Pigeon.ADM do
 
     defp adm_opts do
       [
-        adapter: Pigeon.ADM, 
-        client_id: "client_id", 
+        adapter: Pigeon.ADM,
+        client_id: "client_id",
         client_secret: "secret"
       ]
     end
@@ -144,6 +144,7 @@ defmodule Pigeon.ADM do
   @behaviour Pigeon.Adapter
 
   import Pigeon.Tasks, only: [process_on_response: 1]
+  alias Pigeon.AdapterHelper
   alias Pigeon.ADM.{Config, ResultParser, Token}
   alias Pigeon.HTTP.RequestQueue
   require Logger
@@ -157,37 +158,53 @@ defmodule Pigeon.ADM do
 
     Config.validate!(config)
 
-    {:ok, socket} = Mint.HTTP.connect(:https, "api.amazon.com", 443)
-
-    {:ok,
-     %{
-       config: config,
-       access_token: nil,
-       access_token_refreshed_datetime_erl: {{0, 0, 0}, {0, 0, 0}},
-       access_token_expiration_seconds: 0,
-       access_token_type: nil,
-       socket: socket,
-       queue: RequestQueue.new()
-     }}
-  end
-
-  @impl true
-  def handle_push(notification, state) do
-    case refresh_access_token_if_needed(state) do
-      {:ok, state} ->
-        {:ok, state} = do_push(notification, state)
-        {:noreply, state}
+    case connect_socket() do
+      {:ok, socket} ->
+        {:ok,
+         %{
+           config: config,
+           access_token: nil,
+           access_token_refreshed_datetime_erl: {{0, 0, 0}, {0, 0, 0}},
+           access_token_expiration_seconds: 0,
+           access_token_type: nil,
+           socket: socket,
+           queue: RequestQueue.new()
+         }}
 
       {:error, reason} ->
-        notification
-        |> Map.put(:response, reason)
-        |> process_on_response()
-
-        {:noreply, state}
+        {:stop, reason}
     end
   end
 
   @impl true
+  def handle_push(notification, state) do
+    %{socket: socket} = state
+
+    Mint.HTTP.open?(socket)
+    |> if do
+      case refresh_access_token_if_needed(state) do
+        {:ok, state} ->
+          do_push(notification, state)
+
+        {:error, reason} ->
+          notification
+          |> Map.put(:response, reason)
+          |> process_on_response()
+
+          {:noreply, state}
+      end
+    else
+      AdapterHelper.requeue_notification(notification)
+
+      reconnect_or_exit(state)
+    end
+  end
+
+  @impl true
+  def handle_info({:closed, _}, state) do
+    reconnect_or_exit(state)
+  end
+
   def handle_info(msg, state) do
     Pigeon.HTTP.handle_info(msg, state, &process_response/1)
   end
@@ -300,12 +317,43 @@ defmodule Pigeon.ADM do
     method = "POST"
     path = adm_path(notification.registration_id)
 
-    {:ok, socket, ref} =
-      Mint.HTTP.request(socket, method, path, headers, body)
+    Mint.HTTP.request(socket, method, path, headers, body)
+    |> case do
+      {:ok, socket, ref} ->
+        new_q = RequestQueue.add(queue, ref, notification)
+        {:noreply, %{state | queue: new_q, socket: socket}}
 
-    new_q = RequestQueue.add(queue, ref, notification)
+      _ ->
+        AdapterHelper.requeue_notification(notification)
 
-    {:ok, %{state | queue: new_q, socket: socket}}
+        {:noreply, state}
+    end
+  end
+
+  @max_retries 3
+
+  defp connect_socket(retries \\ @max_retries) do
+    case Mint.HTTP.connect(:https, "api.amazon.com", 443) do
+      {:ok, socket} ->
+        {:ok, socket}
+
+      {:error, reason} ->
+        if retries > 0 do
+          connect_socket(retries - 1)
+        else
+          {:error, reason}
+        end
+    end
+  end
+
+  defp reconnect_or_exit(state) do
+    case connect_socket() do
+      {:ok, socket} ->
+        {:noreply, %{state | socket: socket}}
+
+      {:error, reason} ->
+        {:stop, reason}
+    end
   end
 
   @spec adm_path(String.t()) :: String.t()

--- a/lib/pigeon/apns.ex
+++ b/lib/pigeon/apns.ex
@@ -164,9 +164,9 @@ defmodule Pigeon.APNS do
 
   import Pigeon.Tasks, only: [process_on_response: 1]
 
-  alias Pigeon.Configurable
+  alias Pigeon.{AdapterHelper, Configurable}
   alias Pigeon.APNS.{ConfigParser, Error}
-  alias Pigeon.HTTP.{Request, RequestQueue}
+  alias Pigeon.HTTP.Request
 
   require Logger
 
@@ -177,7 +177,7 @@ defmodule Pigeon.APNS do
 
     state = %__MODULE__{config: config}
 
-    case Configurable.connect(config) do
+    case AdapterHelper.connect_socket(config) do
       {:ok, socket} ->
         Configurable.schedule_ping(config)
         {:ok, %{state | socket: socket}}
@@ -189,24 +189,7 @@ defmodule Pigeon.APNS do
 
   @impl true
   def handle_push(notification, state) do
-    %{config: config, queue: queue, socket: socket} = state
-
-    headers = Configurable.push_headers(config, notification, [])
-    payload = Configurable.push_payload(config, notification, [])
-    method = "POST"
-    path = "/3/device/#{notification.device_token}"
-
-    {:ok, socket, ref} =
-      Mint.HTTP.request(socket, method, path, headers, payload)
-
-    new_q = RequestQueue.add(queue, ref, notification)
-
-    state =
-      state
-      |> Map.put(:socket, socket)
-      |> Map.put(:queue, new_q)
-
-    {:noreply, state}
+    AdapterHelper.handle_push(notification, state, &request_path/2)
   end
 
   @impl true
@@ -217,15 +200,8 @@ defmodule Pigeon.APNS do
     {:noreply, %{state | socket: socket}}
   end
 
-  def handle_info({:closed, _}, %{config: config} = state) do
-    case Configurable.connect(config) do
-      {:ok, socket} ->
-        Configurable.schedule_ping(config)
-        {:noreply, %{state | socket: socket}}
-
-      {:error, reason} ->
-        {:stop, reason}
-    end
+  def handle_info({:closed, _}, state) do
+    AdapterHelper.reconnect_or_exit(state)
   end
 
   def handle_info(msg, state) do
@@ -256,5 +232,9 @@ defmodule Pigeon.APNS do
       {^key, val} -> val
       nil -> nil
     end
+  end
+
+  defp request_path(_config, notification) do
+    {"POST", "/3/device/#{notification.device_token}"}
   end
 end

--- a/lib/pigeon/backoff_worker.ex
+++ b/lib/pigeon/backoff_worker.ex
@@ -1,0 +1,23 @@
+defmodule Pigeon.BackoffWorker do
+  @moduledoc false
+
+  use GenServer
+
+  def start_link(opts) do
+    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl GenServer
+  def init(_opts) do
+    {:ok, nil}
+  end
+
+  @impl GenServer
+  def handle_info({:push, impl, notification, opts}, state) do
+    opts = Keyword.merge(opts, impl: impl)
+
+    Pigeon.push(impl, notification, opts)
+
+    {:noreply, state}
+  end
+end

--- a/lib/pigeon/dispatcher.ex
+++ b/lib/pigeon/dispatcher.ex
@@ -82,6 +82,7 @@ defmodule Pigeon.Dispatcher do
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts] do
       @otp_app opts[:otp_app]
+      @retries opts[:retries] || 3
 
       def child_spec(opts \\ []) do
         config_opts = Application.get_env(@otp_app, __MODULE__, [])
@@ -102,7 +103,45 @@ defmodule Pigeon.Dispatcher do
       Sends a push notification with given options.
       """
       def push(notification, opts \\ []) do
-        Pigeon.push(__MODULE__, notification, opts)
+        opts = Keyword.merge(opts, impl: __MODULE__)
+        current_try = Keyword.get(opts, :current_try, 0)
+
+        case {current_try, @retries} do
+          {max_tries, max_tries} ->
+            notification
+            |> Map.put(:response, :failed_after_retries)
+            |> Pigeon.Tasks.process_on_response()
+
+          {0, _} ->
+            opts = Keyword.put(opts, :current_try, 1)
+
+            Pigeon.push(__MODULE__, notification, opts)
+
+          {current_try, retries} when current_try < retries ->
+            opts = Keyword.put(opts, :current_try, current_try + 1)
+
+            backoff = backoff(current_try)
+
+            Process.send_after(
+              Pigeon.BackoffWorker,
+              {:push, __MODULE__, notification, opts},
+              backoff
+            )
+
+          _ ->
+            Pigeon.push(__MODULE__, notification, opts)
+        end
+      end
+
+      defp backoff(current_try) do
+        # Exponential backoff with jitter
+        # 1 second base delay
+        base_delay = 1000
+        exponential_delay = base_delay * :math.pow(2, current_try)
+        # Add jitter: random value between 0 and exponential_delay
+        jitter = :rand.uniform() * exponential_delay
+
+        trunc(exponential_delay + jitter)
       end
     end
   end
@@ -122,6 +161,10 @@ defmodule Pigeon.Dispatcher do
       for index <- 1..(opts[:pool_size] || Pigeon.default_pool_size()) do
         Supervisor.child_spec({Pigeon.DispatcherWorker, opts}, id: index)
       end
+
+    children = [
+      Pigeon.BackoffWorker | children
+    ]
 
     Supervisor.init(children, strategy: :one_for_one)
   end

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -141,23 +141,18 @@ defmodule Pigeon.FCM do
 
   @impl Pigeon.Adapter
   def handle_push(notification, state) do
-    %{config: config, queue: queue, socket: socket} = state
-    headers = Configurable.push_headers(config, notification, [])
-    payload = Configurable.push_payload(config, notification, [])
-    method = "POST"
-    path = "/v1/projects/#{config.project_id}/messages:send"
+    %{socket: socket} = state
 
-    {:ok, socket, ref} =
-      Mint.HTTP.request(socket, method, path, headers, payload)
+    Mint.HTTP.open?(socket)
+    |> if do
+      # if the the connection reports, the request might still report an error
+      # There might be a race condition between requesting the socket state and doing the action request
+      do_request(notification, state)
+    else
+      requeue_notification(notification)
 
-    new_q = RequestQueue.add(queue, ref, notification)
-
-    state =
-      state
-      |> Map.put(:socket, socket)
-      |> Map.put(:queue, new_q)
-
-    {:noreply, state}
+      reconnect_or_exit(state)
+    end
   end
 
   @impl Pigeon.Adapter
@@ -168,15 +163,8 @@ defmodule Pigeon.FCM do
     {:noreply, %{state | socket: socket}}
   end
 
-  def handle_info({:closed, _}, %{config: config} = state) do
-    case connect_socket(config) do
-      {:ok, socket} ->
-        Configurable.schedule_ping(config)
-        {:noreply, %{state | socket: socket}}
-
-      {:error, reason} ->
-        {:stop, reason}
-    end
+  def handle_info({:closed, _}, state) do
+    reconnect_or_exit(state)
   end
 
   def handle_info(msg, state) do
@@ -202,6 +190,34 @@ defmodule Pigeon.FCM do
     end
   end
 
+  defp do_request(notification, state) do
+    %{config: config, queue: queue, socket: socket} = state
+    headers = Configurable.push_headers(config, notification, [])
+    payload = Configurable.push_payload(config, notification, [])
+    method = "POST"
+    path = "/v1/projects/#{config.project_id}/messages:send"
+
+    Mint.HTTP.request(socket, method, path, headers, payload)
+    |> case do
+      {:ok, socket, ref} ->
+        new_q = RequestQueue.add(queue, ref, notification)
+
+        state =
+          state
+          |> Map.put(:socket, socket)
+          |> Map.put(:queue, new_q)
+
+        {:noreply, state}
+
+      _ ->
+        requeue_notification(notification)
+
+        # nothing changes, request failed, notification is requeued
+        # if socket got closed the next request will attempt to reopen it
+        {:noreply, state}
+    end
+  end
+
   @spec connect_socket(Config.t()) :: {:ok, Mint.HTTP2.t()} | {:error, term()}
   defp connect_socket(config), do: connect_socket(config, @max_retries)
 
@@ -216,6 +232,34 @@ defmodule Pigeon.FCM do
         else
           {:error, reason}
         end
+    end
+  end
+
+  defp requeue_notification(%{__meta__: %{impl: impl}} = notification)
+       when is_atom(impl) and not is_nil(impl) do
+    opts = notification.__meta__ |> Map.from_struct() |> Map.to_list()
+
+    apply(impl, :push, [
+      notification,
+      opts
+    ])
+  end
+
+  defp requeue_notification(_notification) do
+    # Do nothing, push is sync, there is no retry in this case
+    :ok
+  end
+
+  defp reconnect_or_exit(state) do
+    %{config: config} = state
+
+    case connect_socket(config) do
+      {:ok, socket} ->
+        Configurable.schedule_ping(config)
+        {:noreply, %{state | socket: socket}}
+
+      {:error, reason} ->
+        {:stop, reason}
     end
   end
 end

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -104,20 +104,17 @@ defmodule Pigeon.FCM do
   for more details.
   """
 
-  @max_retries 3
-
   defstruct config: nil,
             queue: Pigeon.HTTP.RequestQueue.new(),
-            retries: @max_retries,
             socket: nil
 
   @behaviour Pigeon.Adapter
 
   import Pigeon.Tasks, only: [process_on_response: 1]
 
-  alias Pigeon.Configurable
-  alias Pigeon.FCM.{Config, Error}
-  alias Pigeon.HTTP.{Request, RequestQueue}
+  alias Pigeon.{AdapterHelper, Configurable}
+  alias Pigeon.FCM.Error
+  alias Pigeon.HTTP.Request
 
   require Logger
 
@@ -129,7 +126,7 @@ defmodule Pigeon.FCM do
 
     state = %__MODULE__{config: config}
 
-    case connect_socket(config) do
+    case AdapterHelper.connect_socket(config) do
       {:ok, socket} ->
         Configurable.schedule_ping(config)
         {:ok, %{state | socket: socket}}
@@ -141,18 +138,7 @@ defmodule Pigeon.FCM do
 
   @impl Pigeon.Adapter
   def handle_push(notification, state) do
-    %{socket: socket} = state
-
-    Mint.HTTP.open?(socket)
-    |> if do
-      # if the the connection reports, the request might still report an error
-      # There might be a race condition between requesting the socket state and doing the action request
-      do_request(notification, state)
-    else
-      requeue_notification(notification)
-
-      reconnect_or_exit(state)
-    end
+    AdapterHelper.handle_push(notification, state, &request_path/2)
   end
 
   @impl Pigeon.Adapter
@@ -164,7 +150,7 @@ defmodule Pigeon.FCM do
   end
 
   def handle_info({:closed, _}, state) do
-    reconnect_or_exit(state)
+    AdapterHelper.reconnect_or_exit(state)
   end
 
   def handle_info(msg, state) do
@@ -190,76 +176,7 @@ defmodule Pigeon.FCM do
     end
   end
 
-  defp do_request(notification, state) do
-    %{config: config, queue: queue, socket: socket} = state
-    headers = Configurable.push_headers(config, notification, [])
-    payload = Configurable.push_payload(config, notification, [])
-    method = "POST"
-    path = "/v1/projects/#{config.project_id}/messages:send"
-
-    Mint.HTTP.request(socket, method, path, headers, payload)
-    |> case do
-      {:ok, socket, ref} ->
-        new_q = RequestQueue.add(queue, ref, notification)
-
-        state =
-          state
-          |> Map.put(:socket, socket)
-          |> Map.put(:queue, new_q)
-
-        {:noreply, state}
-
-      _ ->
-        requeue_notification(notification)
-
-        # nothing changes, request failed, notification is requeued
-        # if socket got closed the next request will attempt to reopen it
-        {:noreply, state}
-    end
-  end
-
-  @spec connect_socket(Config.t()) :: {:ok, Mint.HTTP2.t()} | {:error, term()}
-  defp connect_socket(config), do: connect_socket(config, @max_retries)
-
-  defp connect_socket(config, tries) do
-    case Configurable.connect(config) do
-      {:ok, socket} ->
-        {:ok, socket}
-
-      {:error, reason} ->
-        if tries > 0 do
-          connect_socket(config, tries - 1)
-        else
-          {:error, reason}
-        end
-    end
-  end
-
-  defp requeue_notification(%{__meta__: %{impl: impl}} = notification)
-       when is_atom(impl) and not is_nil(impl) do
-    opts = notification.__meta__ |> Map.from_struct() |> Map.to_list()
-
-    apply(impl, :push, [
-      notification,
-      opts
-    ])
-  end
-
-  defp requeue_notification(_notification) do
-    # Do nothing, push is sync, there is no retry in this case
-    :ok
-  end
-
-  defp reconnect_or_exit(state) do
-    %{config: config} = state
-
-    case connect_socket(config) do
-      {:ok, socket} ->
-        Configurable.schedule_ping(config)
-        {:noreply, %{state | socket: socket}}
-
-      {:error, reason} ->
-        {:stop, reason}
-    end
+  defp request_path(config, _notification) do
+    {"POST", "/v1/projects/#{config.project_id}/messages:send"}
   end
 end

--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -4,7 +4,8 @@ defmodule Pigeon.FCM.Config do
   defstruct auth: nil,
             project_id: nil,
             uri: ~c"fcm.googleapis.com",
-            port: 443
+            port: 443,
+            retries: 3
 
   @typedoc """
   The name, or custom module, of your Goth implementation, e.g. `YourApp.Goth`.
@@ -17,7 +18,8 @@ defmodule Pigeon.FCM.Config do
           auth: nil | auth(),
           project_id: nil | String.t(),
           uri: String.t(),
-          port: pos_integer()
+          port: pos_integer(),
+          retries: pos_integer()
         }
 
   @doc ~S"""
@@ -43,7 +45,8 @@ defmodule Pigeon.FCM.Config do
       auth: opts[:auth],
       port: Map.get(opts, :port, 443),
       project_id: opts[:project_id],
-      uri: Map.get(opts, :uri, ~c"fcm.googleapis.com")
+      uri: Map.get(opts, :uri, ~c"fcm.googleapis.com"),
+      retries: Map.get(opts, :retries, 3)
     }
   end
 end

--- a/lib/pigeon/fcm/notification.ex
+++ b/lib/pigeon/fcm/notification.ex
@@ -46,9 +46,9 @@ defmodule Pigeon.FCM.Notification do
   FCM notification target. Must be one of the following:
 
   - `{:token, "string"}` - Registration token to send a message to.
-  - `{:topic, "string"}` - Topic name to send a message to, e.g. "weather". 
+  - `{:topic, "string"}` - Topic name to send a message to, e.g. "weather".
     Note: "/topics/" prefix should not be provided.
-  - `{:condition, "string"}` - Condition to send a message to, e.g. "'foo' 
+  - `{:condition, "string"}` - Condition to send a message to, e.g. "'foo'
     in topics && 'bar' in topics".
   """
   @type target :: {:token, binary} | {:topic, binary} | {:condition, binary}

--- a/lib/pigeon/http.ex
+++ b/lib/pigeon/http.ex
@@ -26,6 +26,18 @@ defmodule Pigeon.HTTP do
 
         {:noreply, %{state | queue: queue, socket: socket}}
 
+      {:error, socket, %Mint.HTTPError{reason: {:server_closed_connection, _}},
+       _responses} ->
+        send(self(), {:closed, socket})
+
+      {
+        :error,
+        socket,
+        %Mint.HTTPError{reason: {:server_closed_connection, _, _}},
+        _responses
+      } ->
+        send(self(), {:closed, socket})
+
       {:error, socket, error, _responses} ->
         error |> inspect(pretty: true) |> Logger.error()
         {:noreply, %{state | socket: socket}}

--- a/lib/pigeon/metadata.ex
+++ b/lib/pigeon/metadata.ex
@@ -4,8 +4,10 @@ defmodule Pigeon.Metadata do
   """
 
   @type t :: %__MODULE__{
-          on_response: Pigeon.on_response() | nil
+          on_response: Pigeon.on_response() | nil,
+          impl: atom() | nil,
+          current_try: pos_integer()
         }
 
-  defstruct on_response: nil
+  defstruct on_response: nil, impl: nil, current_try: 0
 end


### PR DESCRIPTION
This handles error when the server closes connections.
The second commit implements a check for a open connection but it is not very resilient yet.
If the reconnect fails, the notification get's lost, either there needs to be some recovery mechanism or the response handler needs to be called.

https://github.com/codedge-llc/pigeon/issues/299