### PR TITLE
Redact PrivateKeyInfo

### DIFF
--- a/lib/pigeon/apns/config_parser.ex
+++ b/lib/pigeon/apns/config_parser.ex
@@ -50,6 +50,7 @@ defmodule Pigeon.APNS.ConfigParser do
       case Map.get(acc, key) do
         bin when is_binary(bin) -> Map.put(acc, key, @filtered)
         {:RSAPrivateKey, _bin} -> Map.put(acc, key, @filtered)
+        {:PrivateKeyInfo, _bin} -> Map.put(acc, key, @filtered)
         _ -> acc
       end
     end)


### PR DESCRIPTION
Decoded PEM might be a cert, an RSA private key or private key info. The latter is not redacted when raising config error.