### PR TITLE
(hack) fix handshake failure caused by wildcard-nonmatch

### DIFF
--- a/lib/pigeon/fcm/config.ex
+++ b/lib/pigeon/fcm/config.ex
@@ -79,6 +79,12 @@ defimpl Pigeon.Configurable, for: Pigeon.FCM.Config do
         {:active, :once},
         {:packet, :raw},
         {:reuseaddr, true},
+        # HACK fcm.googleapis.com gives back a cert with '*.googleapis.com', but by
+        # default, :ssl.connect does not accept wildcards here. Provising
+        # server_name_indication does not produce another cert
+        {:customize_hostname_check, [
+            match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
+          ]},
         {:alpn_advertised_protocols, [<<"h2">>]}
       ]
       |> add_port(config)


### PR DESCRIPTION
Problem: Pigeon cannot connect to `fcm.googleapis.com` anymore.

```
{:current_stacktrace, [{Process, :info, 2, [file: ~c"lib/process.ex", line: 864]}, {Pigeon.Http2.Client.Kadabra, :connect, 3, [file: ~c"lib/pigeon/http2/kadabra.ex", line: 12]}, {Pigeon.FCM, :connect_socket, 2, [file: ~c"lib/pigeon/fcm.ex", line: 191]}, {Pigeon.FCM, :init, 1, [file: ~c"lib/pigeon/fcm.ex", line: 128]}, {Pigeon.DispatcherWorker, :init, 1, [file: ~c"lib/pigeon/dispatcher_worker.ex", line: 13]}, {:gen_server, :init_it, 2, [file: ~c"gen_server.erl", line: 2229]}, {:gen_server, :init_it, 6, [file: ~c"gen_server.erl", line: 2184]}, {:proc_lib, :init_p_do_apply, 3, [file: ~c"proc_lib.erl", line: 329]}]}
[notice] TLS :client: In state :wait_cert_cr at ssl_handshake.erl:2186 generated CLIENT ALERT: Fatal - Handshake Failure
 - {:bad_cert,
 {:hostname_check_failed, {:requested, ~c"fcm.googleapis.com"},
  {:received,
   [
     dNSName: ~c"upload.video.google.com",
     dNSName: ~c"*.clients.google.com",
     dNSName: ~c"*.docs.google.com",
     dNSName: ~c"*.drive.google.com",
     dNSName: ~c"*.gdata.youtube.com",
     dNSName: ~c"*.googleapis.com",
     dNSName: ~c"*.photos.google.com",
     dNSName: ~c"*.youtube-3rd-party.com",
     dNSName: ~c"upload.google.com",
     dNSName: ~c"*.upload.google.com",
     dNSName: ~c"upload.youtube.com",
     dNSName: ~c"*.upload.youtube.com",
     dNSName: ~c"uploads.stage.gdata.youtube.com",
     dNSName: ~c"bg-call-donation.goog",
     dNSName: ~c"bg-call-donation-alpha.goog",
     dNSName: ~c"bg-call-donation-canary.goog",
     dNSName: ~c"bg-call-donation-dev.goog"
   ]}}}
```
 
As far as I understand, Erlang's :ssl.connect expects a server cert that matches the host exactly and rejects wildcard certificates - so `"*.googleapis.com"` is ignored. I tried adding `server_name_indication: "fcm.googleapis.com" to the `ssl_opts`, but got the same cert back.

I am *not* 100% sure if this an appropriate solution, but it works as a quick fix.