### PR TITLE
FCM handle Mint connection closed case

### DIFF
--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -147,17 +147,48 @@ defmodule Pigeon.FCM do
     method = "POST"
     path = "/v1/projects/#{config.project_id}/messages:send"
 
-    {:ok, socket, ref} =
-      Mint.HTTP.request(socket, method, path, headers, payload)
+    case Mint.HTTP.request(socket, method, path, headers, payload) do
+      {:ok, socket, ref} ->
+        new_q = RequestQueue.add(queue, ref, notification)
 
-    new_q = RequestQueue.add(queue, ref, notification)
+        state =
+          state
+          |> Map.put(:socket, socket)
+          |> Map.put(:queue, new_q)
 
-    state =
-      state
-      |> Map.put(:socket, socket)
-      |> Map.put(:queue, new_q)
+        {:noreply, state}
 
-    {:noreply, state}
+      {:error, _socket, %Mint.HTTPError{reason: :closed}} ->
+        Logger.warning("FCM connection closed. Reconnecting...")
+
+        case connect_socket(config) do
+          {:ok, socket} ->
+            Configurable.schedule_ping(config)
+
+            case Mint.HTTP.request(socket, method, path, headers, payload) do
+              {:ok, socket, ref} ->
+                new_q = RequestQueue.add(queue, ref, notification)
+
+                state =
+                  state
+                  |> Map.put(:socket, socket)
+                  |> Map.put(:queue, new_q)
+
+                {:noreply, state}
+
+              {:error, socket, reason} ->
+                Logger.error("Retry failed: #{inspect(reason)}")
+                {:noreply, %{state | socket: socket}}
+            end
+
+          {:error, reason} ->
+            {:stop, reason}
+        end
+
+      {:error, socket, reason} ->
+        Logger.error("FCM request failed: #{inspect(reason)}")
+        {:noreply, %{state | socket: socket}}
+    end
   end
 
   @impl Pigeon.Adapter

--- a/lib/pigeon/fcm.ex
+++ b/lib/pigeon/fcm.ex
@@ -178,25 +178,46 @@ defmodule Pigeon.FCM do
 
               {:error, socket, reason} ->
                 Logger.error("Retry failed: #{inspect(reason)}")
+                fail_notification(notification, reason)
                 {:noreply, %{state | socket: socket}}
             end
 
           {:error, reason} ->
+            fail_notification(notification, reason)
             {:stop, reason}
         end
 
       {:error, socket, reason} ->
         Logger.error("FCM request failed: #{inspect(reason)}")
+        fail_notification(notification, reason)
         {:noreply, %{state | socket: socket}}
     end
   end
 
   @impl Pigeon.Adapter
   def handle_info(:ping, %{config: config, socket: socket} = state) do
-    {:ok, socket, _ref} = Mint.HTTP2.ping(socket)
-    Configurable.schedule_ping(config)
+    case Mint.HTTP2.ping(socket) do
+      {:ok, socket, _ref} ->
+        Configurable.schedule_ping(config)
+        {:noreply, %{state | socket: socket}}
 
-    {:noreply, %{state | socket: socket}}
+      {:error, _socket, %Mint.HTTPError{reason: :closed}} ->
+        Logger.warning("FCM ping found closed connection. Reconnecting...")
+
+        case connect_socket(config) do
+          {:ok, socket} ->
+            Configurable.schedule_ping(config)
+            {:noreply, %{state | socket: socket}}
+
+          {:error, reason} ->
+            {:stop, reason}
+        end
+
+      {:error, socket, reason} ->
+        Logger.error("FCM ping failed: #{inspect(reason)}")
+        Configurable.schedule_ping(config)
+        {:noreply, %{state | socket: socket}}
+    end
   end
 
   def handle_info({:closed, _}, %{config: config} = state) do
@@ -231,6 +252,16 @@ defmodule Pigeon.FCM do
         |> Map.put(:response, Error.parse(error))
         |> process_on_response()
     end
+  end
+
+  # Ensures a notification that never made it onto the wire still invokes
+  # the caller's on_response callback, instead of silently vanishing.
+  @spec fail_notification(term(), term()) :: :ok
+  defp fail_notification(notification, reason) do
+    notification
+    |> Map.put(:error, reason)
+    |> Map.put(:response, :network_error)
+    |> process_on_response()
   end
 
   @spec connect_socket(Config.t()) :: {:ok, Mint.HTTP2.t()} | {:error, term()}


### PR DESCRIPTION
I've runned into this error when i switched to the latest version that uses mint and not kadabra
it's basically straightforward, the closed connection case is not handled so im handling it 

`14:50:59.542 [error] GenServer #PID<0.2806.0> terminating
Jul 11 14:50:59 instance-20250220-1457 zawajonlypheonix[2408916]: ** (MatchError) no match of right hand side value: {:error, %Mint.HTTP2{transport: Mint.Core.Transport.SSL, socket: {:sslsocket, {:gen_tcp, #Port<0.157>, :tls_connection, :undefined}, [#PID<0.2810.0>, #PID<0.2809.0>]}, mode: :active, hostname: "fcm.googleapis.com", port: 443, scheme: "https", authority: "fcm.googleapis.com", state: :closed, buffer: "", send_window_size: 1048576, receive_window_size: 16777216, receive_window_remaining: 16777216, receive_window_update_threshold: 160000, encode_table: %HPAX.Table{protocol_max_table_size: 4096, max_table_size: 4096, huffman_encoding: :never, entries: [], size: 0, length: 0, pending_minimum_resize: nil}, decode_table: %HPAX.Table{protocol_max_table_size: 4096, max_table_size: 4096, huffman_encoding: :never, entries: [], size: 0, length: 0, pending_minimum_resize: nil}, ping_queue: {[], []}, client_settings_queue: {[], []}, next_stream_id: 3, streams: %{}, open_client_stream_count: 0, open_server_stream_count: 0, reserved_server_stream_count: 0, ref_to_stream_id: %{}, server_settings: %{max_frame_size: 16384, initial_window_size: 1048576, max_concurrent_streams: 100, max_header_list_size: 65536, enable_connect_protocol: false, enable_push: true}, client_settings: %{max_frame_size: 16777215, initial_window_size: 2147483647, max_concurrent_streams: 100, max_header_list_size: 262144, enable_push: true}, headers_being_processed: nil, proxy_headers: [], private: %{}, log: false}, %Mint.HTTPError{reason: :closed, module: Mint.HTTP2}}`

this is just my approach to make it work for my own use for now as for version 2.1 is not published yet, maybe this is fixed in the said version