### PR TITLE
fix: various new error atoms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   came back. ([#311](https://github.com/codedge-llc/pigeon/pull/311))
 - FCM connections stay alive with periodic pings, the same way APNS connections
   already did. Tune it with the new `:ping_period` option. ([#311](https://github.com/codedge-llc/pigeon/pull/311))
+- `:unauthenticated` FCM error response when FCM rejects the service account itself.
+  Before, a bad or expired service account came back as `:unknown_error`. ([#312](https://github.com/codedge-llc/pigeon/pull/312))
+- `:bad_environment_key_id_in_token` and `:unrelated_key_id_in_token` APNS error
+  responses, matching the two token authentication reasons Apple added. ([#312](https://github.com/codedge-llc/pigeon/pull/312))
 
 **Changed**
 

--- a/lib/pigeon/apns/error.ex
+++ b/lib/pigeon/apns/error.ex
@@ -21,6 +21,9 @@ defmodule Pigeon.APNS.Error do
 
   defp parse_response("BadDeviceToken"), do: :bad_device_token
 
+  defp parse_response("BadEnvironmentKeyIdInToken"),
+    do: :bad_environment_key_id_in_token
+
   defp parse_response("BadExpirationDate"), do: :bad_expiration_date
 
   defp parse_response("BadMessageId"), do: :bad_message_id
@@ -73,6 +76,9 @@ defmodule Pigeon.APNS.Error do
   defp parse_response("TopicDisallowed"), do: :topic_disallowed
 
   defp parse_response("Unregistered"), do: :unregistered
+
+  defp parse_response("UnrelatedKeyIdInToken"),
+    do: :unrelated_key_id_in_token
 
   defp parse_response(_), do: :unknown_error
 end

--- a/lib/pigeon/apns/notification.ex
+++ b/lib/pigeon/apns/notification.ex
@@ -66,38 +66,48 @@ defmodule Pigeon.APNS.Notification do
           | :success
           | :timeout
 
+  @typedoc ~S"""
+  APNS error response
+
+  Each atom is the snake_case form of the `reason` in the APNS response body.
+  See [Handling notification responses from APNs](https://developer.apple.com/documentation/usernotifications/handling-notification-responses-from-apns)
+  for the meaning of each one. `:unknown_error` covers any reason Pigeon does
+  not recognize.
+  """
   @type error_response ::
-          :bad_collapse_id
+          :bad_certificate
+          | :bad_certificate_environment
+          | :bad_collapse_id
           | :bad_device_token
+          | :bad_environment_key_id_in_token
           | :bad_expiration_date
           | :bad_message_id
+          | :bad_path
           | :bad_priority
           | :bad_topic
           | :device_token_not_for_topic
           | :duplicate_headers
+          | :expired_provider_token
+          | :expired_token
+          | :forbidden
           | :idle_timeout
+          | :internal_server_error
+          | :invalid_provider_token
           | :invalid_push_type
+          | :method_not_allowed
           | :missing_device_token
+          | :missing_provider_token
           | :missing_topic
           | :payload_empty
-          | :topic_disallowed
-          | :bad_certificate
-          | :bad_certificate_environment
-          | :expired_provider_token
-          | :forbidden
-          | :invalid_provider_token
-          | :missing_provider_token
-          | :bad_path
-          | :method_not_allowed
-          | :expired_token
-          | :unregistered
           | :payload_too_large
-          | :too_many_provider_token_updates
-          | :too_many_requests
-          | :internal_server_error
           | :service_unavailable
           | :shutdown
+          | :too_many_provider_token_updates
+          | :too_many_requests
+          | :topic_disallowed
           | :unknown_error
+          | :unregistered
+          | :unrelated_key_id_in_token
 
   @doc """
   Returns an `APNS.Notification` struct with given message, device token, and

--- a/lib/pigeon/fcm/error.ex
+++ b/lib/pigeon/fcm/error.ex
@@ -23,6 +23,7 @@ defmodule Pigeon.FCM.Error do
   defp parse_response("QUOTA_EXCEEDED"), do: :quota_exceeded
   defp parse_response("SENDER_ID_MISMATCH"), do: :sender_id_mismatch
   defp parse_response("THIRD_PARTY_AUTH_ERROR"), do: :third_party_auth_error
+  defp parse_response("UNAUTHENTICATED"), do: :unauthenticated
   defp parse_response("UNAVAILABLE"), do: :unavailable
   defp parse_response("UNREGISTERED"), do: :unregistered
   defp parse_response("UNSPECIFIED_ERROR"), do: :unspecified_error

--- a/lib/pigeon/fcm/notification.ex
+++ b/lib/pigeon/fcm/notification.ex
@@ -52,16 +52,25 @@ defmodule Pigeon.FCM.Notification do
           | :success
           | :timeout
 
+  @typedoc ~S"""
+  FCM error response
+
+  Most map to the `errorCode` in the FCM v1 error details. `:permission_denied`
+  and `:unauthenticated` come from the gRPC `status` when FCM rejects the
+  service account itself. `:unknown_error` covers anything unrecognized.
+  """
   @type error_response ::
-          :unspecified_error
+          :internal
           | :invalid_argument
-          | :unregistered
-          | :sender_id_mismatch
+          | :permission_denied
           | :quota_exceeded
-          | :unavailable
-          | :internal
+          | :sender_id_mismatch
           | :third_party_auth_error
+          | :unauthenticated
+          | :unavailable
           | :unknown_error
+          | :unregistered
+          | :unspecified_error
 
   @typedoc ~S"""
   FCM notification target. Must be one of the following:

--- a/test/pigeon/apns/error_test.exs
+++ b/test/pigeon/apns/error_test.exs
@@ -7,6 +7,7 @@ defmodule Pigeon.APNS.ErrorTest do
       {"BadCertificateEnvironment", :bad_certificate_environment},
       {"BadCollapseId", :bad_collapse_id},
       {"BadDeviceToken", :bad_device_token},
+      {"BadEnvironmentKeyIdInToken", :bad_environment_key_id_in_token},
       {"BadExpirationDate", :bad_expiration_date},
       {"BadMessageId", :bad_message_id},
       {"BadPath", :bad_path},
@@ -32,7 +33,8 @@ defmodule Pigeon.APNS.ErrorTest do
       {"TooManyProviderTokenUpdates", :too_many_provider_token_updates},
       {"TooManyRequests", :too_many_requests},
       {"TopicDisallowed", :topic_disallowed},
-      {"Unregistered", :unregistered}
+      {"Unregistered", :unregistered},
+      {"UnrelatedKeyIdInToken", :unrelated_key_id_in_token}
     ]
 
     for {actual, expected} <- reasons do

--- a/test/pigeon/fcm/error_test.exs
+++ b/test/pigeon/fcm/error_test.exs
@@ -161,6 +161,18 @@ defmodule Pigeon.FCM.ErrorTest do
       assert Error.parse(error) == :invalid_argument
     end
 
+    test "returns :unauthenticated when 'status' is 'UNAUTHENTICATED'" do
+      error = %{
+        "code" => 401,
+        "status" => "UNAUTHENTICATED",
+        "message" =>
+          "Request had invalid authentication credentials. Expected OAuth 2 " <>
+            "access token, login cookie or other valid authentication credential."
+      }
+
+      assert Error.parse(error) == :unauthenticated
+    end
+
     test "returns :unknown_error when 'status' is not found" do
       error = %{
         "code" => 500,


### PR DESCRIPTION
**Added**

- `:unauthenticated` FCM error response when FCM rejects the service account itself.
  Before, a bad or expired service account came back as `:unknown_error`. ([#312](https://github.com/codedge-llc/pigeon/pull/312))
- `:bad_environment_key_id_in_token` and `:unrelated_key_id_in_token` APNS error
  responses, matching the two token authentication reasons Apple added. ([#312](https://github.com/codedge-llc/pigeon/pull/312))